### PR TITLE
fix(http-check): Allow multiple instances to be passed

### DIFF
--- a/manifests/integrations/http_check.pp
+++ b/manifests/integrations/http_check.pp
@@ -7,10 +7,10 @@
 #
 # Parameters:
 #   sitename
-#       (Required) The name of the instance.
+#       The name of the instance.
 #
 #   url
-#       (Required) The url to check.
+#       The url to check.
 #
 #   timeout
 #       The (optional) timeout in seconds.
@@ -170,8 +170,8 @@
 #        }]
 #     }
 class datadog_agent::integrations::http_check (
-  String $sitename,
-  String $url,
+  Optional[String] $sitename = undef,
+  Optional[String] $url = undef,
   Optional[String] $username  = undef,
   Optional[Any] $password  = undef,
   Integer $timeout   = 1,


### PR DESCRIPTION
### What does this PR do?

- Allows multiple HTTP checks to be passed at once.

### Motivation

This used to work before and broke because of the types that has been added.

### Additional Notes

### Describe your test plan
