### PR TITLE
Corrected service_enable typehint

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -292,7 +292,7 @@ class datadog_agent (
   String $log_level = 'info',
   Boolean $log_to_syslog = true,
   String $service_ensure = 'running',
-  Boolean $service_enable = true,
+  Variant[Boolean, Enum['manual', 'mask', 'delayed']] $service_enable = true,
   Boolean $manage_repo = true,
   Boolean $manage_dogapi_gem = true,
   Boolean $manage_install = true,


### PR DESCRIPTION
### What does this PR do?

Corrects the type hinting of the service_enable param.

### Motivation

The service_enable param use to allow 'manual', 'mask', delayed' as value in addition to 'true' or 'false.

See also: `manifest/service.pp`

### Additional Notes


### Describe your test plan
