### PR TITLE
Bump kitchen test images for CentOS and Rocky Linux

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -80,7 +80,6 @@ platforms:
     docker_platform: linux/amd64
     privileged: true
     run_options: --cgroupns=host --tmpfs=/run --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
-    publish_all: true
     run_command: /root/start.sh
     provision_command:
     - dnf module -y reset ruby
@@ -107,7 +106,6 @@ platforms:
     platform: rhel # kitchen-docker has issues installing packages otherwises
     docker_platform: linux/amd64
     privileged: true
-    use_cache: false
     run_options: --cgroupns=host --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
     run_command: /root/start.sh
     provision_command:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,194 +14,175 @@ provisioner:
   custom_pre_apply_command: 'cp -r /tmp/modules/* /tmp/kitchen/modules/'
 
 platforms:
-- name: ubuntu-24.04-puppet-8
-  driver:
-    image: 'ubuntu:24.04'
-    provision_command:
-    - apt-get install -y apt-utils apt-transport-https ca-certificates
-    - wget https://apt.puppet.com/puppet8-release-noble.deb
-    - dpkg -i puppet8-release-noble.deb #installs the puppet-agent repo
-    - apt-get update
-    - apt-get install -y puppet-agent rubygems ruby-dev make gcc
-    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+  - name: ubuntu-24.04-puppet-8
+    driver:
+      image: 'ubuntu:24.04'
+      provision_command:
+        - apt-get install -y apt-utils apt-transport-https ca-certificates
+        - wget https://apt.puppet.com/puppet8-release-noble.deb
+        - dpkg -i puppet8-release-noble.deb #installs the puppet-agent repo
+        - apt-get update
+        - apt-get install -y puppet-agent rubygems ruby-dev make gcc
+        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-    - mkdir /home/kitchen/puppet
-    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+        - mkdir /home/kitchen/puppet
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-    - gem install bundler -v '= 2.4.13'
-    - cd /home && bundle install
-    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+        - gem install bundler -v '= 2.4.13'
+        - cd /home && bundle install
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-- name: ubuntu-22.04-puppet-8
-  driver:
-    image: 'ubuntu:22.04'
-    provision_command:
-    - apt-get update
-    - apt-get install -y apt-utils apt-transport-https ca-certificates wget
-    - wget https://apt.puppet.com/puppet8-release-jammy.deb
-    - dpkg -i puppet8-release-jammy.deb #installs the puppet-agent repo
-    - apt-get update
-    - apt-get install -y puppet-agent rubygems ruby-dev make gcc
-    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+  - name: ubuntu-22.04-puppet-8
+    driver:
+      image: 'ubuntu:22.04'
+      provision_command:
+        - apt-get update
+        - apt-get install -y apt-utils apt-transport-https ca-certificates wget
+        - wget https://apt.puppet.com/puppet8-release-jammy.deb
+        - dpkg -i puppet8-release-jammy.deb #installs the puppet-agent repo
+        - apt-get update
+        - apt-get install -y puppet-agent rubygems ruby-dev make gcc
+        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-    - mkdir /home/kitchen/puppet -p
-    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+        - mkdir /home/kitchen/puppet -p
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-    - gem install bundler -v '= 2.4.13'
-    - cd /home && bundle install
-    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+        - gem install bundler -v '= 2.4.13'
+        - cd /home && bundle install
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-- name: ubuntu-20.04-puppet-8
-  driver:
-    image: 'ubuntu:20.04'
-    docker_platform: linux/amd64
-    provision_command:
-    - apt-get install -y apt-utils apt-transport-https ca-certificates make gcc
-    - wget https://apt.puppet.com/puppet8-release-focal.deb
-    - dpkg -i puppet8-release-focal.deb #installs the puppet-agent repo
-    - apt-get update
-    - apt-get install -y puppet-agent rubygems ruby-dev
-    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+  - name: ubuntu-20.04-puppet-7
+    driver:
+      image: 'ubuntu:20.04'
+      docker_platform: linux/amd64
+      provision_command:
+        - apt-get install -y apt-utils apt-transport-https ca-certificates make gcc
+        - wget https://apt.puppet.com/puppet7-release-focal.deb
+        - dpkg -i puppet7-release-focal.deb #installs the puppet-agent repo
+        - apt-get update
+        - apt-get install -y puppet-agent rubygems ruby-dev
+        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-    - mkdir /home/kitchen/puppet
-    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+        - mkdir /home/kitchen/puppet
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-    - gem install bundler -v '= 2.4.13'
-    - cd /home && bundle install
-    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+        - gem install bundler -v '= 2.4.13'
+        - cd /home && bundle install
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-# mirrorlist.centos.org is no longer available for <= centos8/centos-stream8
-# - name: centos-stream8-puppet-8 
-#   driver_config:
-#     image: 'quay.io/centos/centos:stream9'
-#     platform: centosstream
-#   driver:
-#     use_sudo: true
-#     privileged: true
-#     provision_command:
-#     - rpm -Uvh https://yum.puppet.com/puppet8-release-el-8.noarch.rpm #installs the puppet-agent repo
-#     - yum install -y puppet-agent rubygems ruby-devel make gcc
-#     - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+  - name: centos-stream9-puppet-8
+    driver:
+      image: 'datadog/docker-library:chef_kitchen_systemd_centos_9'
+      platform: centosstream
+      docker_platform: linux/amd64
+      privileged: true
+      run_options: --cgroupns=host --tmpfs=/run --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
+      publish_all: true
+      run_command: /root/start.sh
+      provision_command:
+        - dnf module -y reset ruby
+        - dnf module -y enable ruby:3.1
+        - dnf module -y install ruby:3.1/common
 
-#     - mkdir /home/kitchen/puppet -p
-#     - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-#     - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+        - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
+        - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
+        - dnf group install -y "Development Tools"
+        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-#     - gem install bundler -v '= 2.4.13'
-#     # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
-#     - cd /home && bundle install
-#     - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+        - mkdir /home/kitchen/puppet -p
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
+        - gem install bundler -v '= 2.4.13'
+        # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
+        - cd /home && bundle install
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-# TODO: validate module support for CentOS Stream
-#       Debug: Service[datadog-agent](provider=base): Executing 'ps -ef'
-#       Debug: Executing: 'ps -ef'
-#       Error: /Service[datadog-agent]: Could not evaluate: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
-#       Debug: Service[datadog-agent](provider=base): Executing 'ps -ef'
-#       Debug: Executing: 'ps -ef'
-#       Error: /Service[datadog-agent]: Failed to call refresh: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
-#       Error: /Service[datadog-agent]: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
-#- name: centos-stream9-puppet-8
-#  driver:
-#    image: 'quay.io/centos/centos:stream9'
-#    platform: centosstream
+  - name: rocky-9-puppet-8
+    driver:
+      image: 'fannyatdd/docker-rocky9-systemd:test-9'
+      platform: rhel # kitchen-docker has issues installing packages otherwises
+      docker_platform: linux/amd64
+      privileged: true
+      use_cache: false
+      run_options: --cgroupns=host --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
+      run_command: /root/start.sh
+      provision_command:
+        - dnf module -y reset ruby
+        - dnf module -y enable ruby:3.1
+        - dnf module -y install ruby:3.1/common
+
+        - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
+        - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
+        - dnf group install -y "Development Tools"
+        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+
+        - mkdir /home/kitchen/puppet -p
+        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+
+        - gem install bundler -v '= 2.4.13'
+        # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
+        - cd /home && bundle install
+        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+
+#- name: opensuse/leap-15
+#  # Workaround for flakes on initializing opensuse/leap-15:
+#  # => SCP did not finish successfully (255):  (Net::SCP::Error)
+#  transport:
+#    max_ssh_sessions: 1
+#  driver_config:
+#    # we use a custom image that runs systemd
+#    image: 'datadog/docker-library:chef_kitchen_systemd_opensuse_leap_15'
 #    docker_platform: linux/amd64
-#    use_sudo: true
-#    privileged: true
-#    provision_command:
-#    - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
-#    - yum install -y puppet-agent rubygems ruby-devel
-#    - dnf group install -y "Development Tools"
-#    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
-#
-#    - mkdir /home/kitchen/puppet -p
-#    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-#    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
-#
-#    - gem install bundler -v '= 2.4.13'
-#    # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
-#    - cd /home && bundle install
-#    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
-
-
-# TODO: validate module support for Rocky Linux
-#       Debug: Service[datadog-agent](provider=base): Executing 'ps -ef'
-#       Debug: Executing: 'ps -ef'
-#       Error: /Service[datadog-agent]: Could not evaluate: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
-#       Debug: Service[datadog-agent](provider=base): Executing 'ps -ef'
-#       Debug: Executing: 'ps -ef'
-#       Error: /Service[datadog-agent]: Failed to call refresh: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
-#       Error: /Service[datadog-agent]: Execution of 'ps -ef' returned 1: Error: Could not execute posix command: No such file or directory - ps
-#- name: rocky-9-puppet-8
+#    run_command: /root/start.sh
 #  driver:
-#    image: 'rockylinux:9.3'
-#    platform: centosstream # kitchen-docker has issues installing packages otherwises
 #    provision_command:
-#    - dnf install -y https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
-#    - dnf install -y puppet-agent rubygems ruby-devel
-#    - dnf group install -y "Development Tools"
-#    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+#      - zypper ar -G https://yum.puppet.com/puppet/sles/15/x86_64/ puppet-repo
+#      - zypper refresh
+#      - zypper install -y puppet-agent
+#      - export PATH="/opt/puppetlabs/puppet/bin:$PATH"
+#      - ruby -v
+#      - puppet --version
 #
-#    - mkdir /home/kitchen/puppet
-#    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-#    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+#      - gem install bundler -v '= 1.17.3'
+#      - gem install net-ssh -v '= 6.1.0'
+#      - gem install rspec-its -v '= 1.3.1'
+#      - gem install serverspec rspec
+#      - ln -s /usr/bin/rspec.ruby2.7 /usr/bin/rspec
+#      - ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
+#      - mkdir /home/kitchen/puppet
+#      - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+#      - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 #
-#    - gem install bundler -v '= 2.4.13'
-#
-#    - cd /home && bundle install
-#    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
-
-# - name: opensuse/leap-15
-#     # Workaround for flakes on initializing opensuse/leap-15:
-#   # => SCP did not finish successfully (255):  (Net::SCP::Error)
-#   transport:
-#     max_ssh_sessions: 1
-#   driver_config:
-#     # we use a custom image that runs systemd
-#     image: 'datadog/docker-library:chef_kitchen_systemd_opensuse_leap_15'
-#     run_command: /root/start.sh
-#   driver:
-#     provision_command:
-#       - zypper ar -G https://yum.puppet.com/puppet/sles/15/x86_64/ puppet-repo
-#       - zypper install -y puppet-agent ruby=2.5
-#       - gem install bundler -v '= 1.17.3'
-#       - gem install net-ssh -v '= 6.1.0'
-#       - gem install rspec-its -v '= 1.3.1'
-#       - gem install serverspec rspec
-#       - ln -s /usr/bin/rspec.ruby2.5 /usr/bin/rspec
-#       - ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
-#       - mkdir /home/kitchen/puppet
-#       - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-#       - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
-
-#       - cd /home && bundle.ruby2.5 install
-#       - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+#      - cd /home && bundle.ruby2.7 install
+#      - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
 suites:
-- name: dd-agent
-  manifests: init.pp
-  verifier:
-    name: serverspec
-    default_pattern: true
-    additional_install_commmand: source /etc/profile.d/rvm.sh
-    env_vars:
-      TARGET_HOST: 127.0.0.1
-      TARGET_PORT: 2222
-      LOGIN_USER: root
-      LOGIN_PASSWORD: puppet
-- name: dd-installer
-  manifests: init.pp
-  provisioner:
-    manifests_path: environments/etc/installer-manifests
-  verifier:
-    name: serverspec
-    default_pattern: true
-    additional_install_commmand: source /etc/profile.d/rvm.sh
-    env_vars:
-      TARGET_HOST: 127.0.0.1
-      TARGET_PORT: 2222
-      LOGIN_USER: root
-      LOGIN_PASSWORD: puppet
+  - name: dd-agent
+    manifests: init.pp
+    verifier:
+      name: serverspec
+      default_pattern: true
+      additional_install_commmand: source /etc/profile.d/rvm.sh
+      env_vars:
+        TARGET_HOST: 127.0.0.1
+        TARGET_PORT: 2222
+        LOGIN_USER: root
+        LOGIN_PASSWORD: puppet
+  - name: dd-installer
+    manifests: init.pp
+    provisioner:
+      manifests_path: environments/etc/installer-manifests
+    verifier:
+      name: serverspec
+      default_pattern: true
+      additional_install_commmand: source /etc/profile.d/rvm.sh
+      env_vars:
+        TARGET_HOST: 127.0.0.1
+        TARGET_PORT: 2222
+        LOGIN_USER: root
+        LOGIN_PASSWORD: puppet

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,120 +14,120 @@ provisioner:
   custom_pre_apply_command: 'cp -r /tmp/modules/* /tmp/kitchen/modules/'
 
 platforms:
-  - name: ubuntu-24.04-puppet-8
-    driver:
-      image: 'ubuntu:24.04'
-      provision_command:
-        - apt-get install -y apt-utils apt-transport-https ca-certificates
-        - wget https://apt.puppet.com/puppet8-release-noble.deb
-        - dpkg -i puppet8-release-noble.deb #installs the puppet-agent repo
-        - apt-get update
-        - apt-get install -y puppet-agent rubygems ruby-dev make gcc
-        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+- name: ubuntu-24.04-puppet-8
+  driver:
+    image: 'ubuntu:24.04'
+    provision_command:
+    - apt-get install -y apt-utils apt-transport-https ca-certificates
+    - wget https://apt.puppet.com/puppet8-release-noble.deb
+    - dpkg -i puppet8-release-noble.deb #installs the puppet-agent repo
+    - apt-get update
+    - apt-get install -y puppet-agent rubygems ruby-dev make gcc
+    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-        - mkdir /home/kitchen/puppet
-        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+    - mkdir /home/kitchen/puppet
+    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - gem install bundler -v '= 2.4.13'
-        - cd /home && bundle install
-        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+    - gem install bundler -v '= 2.4.13'
+    - cd /home && bundle install
+    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-  - name: ubuntu-22.04-puppet-8
-    driver:
-      image: 'ubuntu:22.04'
-      provision_command:
-        - apt-get update
-        - apt-get install -y apt-utils apt-transport-https ca-certificates wget
-        - wget https://apt.puppet.com/puppet8-release-jammy.deb
-        - dpkg -i puppet8-release-jammy.deb #installs the puppet-agent repo
-        - apt-get update
-        - apt-get install -y puppet-agent rubygems ruby-dev make gcc
-        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+- name: ubuntu-22.04-puppet-8
+  driver:
+    image: 'ubuntu:22.04'
+    provision_command:
+    - apt-get update
+    - apt-get install -y apt-utils apt-transport-https ca-certificates wget
+    - wget https://apt.puppet.com/puppet8-release-jammy.deb
+    - dpkg -i puppet8-release-jammy.deb #installs the puppet-agent repo
+    - apt-get update
+    - apt-get install -y puppet-agent rubygems ruby-dev make gcc
+    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-        - mkdir /home/kitchen/puppet -p
-        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+    - mkdir /home/kitchen/puppet -p
+    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - gem install bundler -v '= 2.4.13'
-        - cd /home && bundle install
-        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+    - gem install bundler -v '= 2.4.13'
+    - cd /home && bundle install
+    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-  - name: ubuntu-20.04-puppet-7
-    driver:
-      image: 'ubuntu:20.04'
-      docker_platform: linux/amd64
-      provision_command:
-        - apt-get install -y apt-utils apt-transport-https ca-certificates make gcc
-        - wget https://apt.puppet.com/puppet7-release-focal.deb
-        - dpkg -i puppet7-release-focal.deb #installs the puppet-agent repo
-        - apt-get update
-        - apt-get install -y puppet-agent rubygems ruby-dev
-        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+- name: ubuntu-20.04-puppet-7
+  driver:
+    image: 'ubuntu:20.04'
+    docker_platform: linux/amd64
+    provision_command:
+    - apt-get install -y apt-utils apt-transport-https ca-certificates make gcc
+    - wget https://apt.puppet.com/puppet7-release-focal.deb
+    - dpkg -i puppet7-release-focal.deb #installs the puppet-agent repo
+    - apt-get update
+    - apt-get install -y puppet-agent rubygems ruby-dev
+    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-        - mkdir /home/kitchen/puppet
-        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+    - mkdir /home/kitchen/puppet
+    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - gem install bundler -v '= 2.4.13'
-        - cd /home && bundle install
-        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+    - gem install bundler -v '= 2.4.13'
+    - cd /home && bundle install
+    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-  - name: centos-stream9-puppet-8
-    driver:
-      image: 'datadog/docker-library:chef_kitchen_systemd_centos_9'
-      platform: centosstream
-      docker_platform: linux/amd64
-      privileged: true
-      run_options: --cgroupns=host --tmpfs=/run --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
-      publish_all: true
-      run_command: /root/start.sh
-      provision_command:
-        - dnf module -y reset ruby
-        - dnf module -y enable ruby:3.1
-        - dnf module -y install ruby:3.1/common
+- name: centos-stream9-puppet-8
+  driver:
+    image: 'datadog/docker-library:chef_kitchen_systemd_centos_9'
+    platform: centosstream
+    docker_platform: linux/amd64
+    privileged: true
+    run_options: --cgroupns=host --tmpfs=/run --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
+    publish_all: true
+    run_command: /root/start.sh
+    provision_command:
+    - dnf module -y reset ruby
+    - dnf module -y enable ruby:3.1
+    - dnf module -y install ruby:3.1/common
 
-        - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
-        - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
-        - dnf group install -y "Development Tools"
-        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+    - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
+    - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
+    - dnf group install -y "Development Tools"
+    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-        - mkdir /home/kitchen/puppet -p
-        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+    - mkdir /home/kitchen/puppet -p
+    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - gem install bundler -v '= 2.4.13'
-        # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
-        - cd /home && bundle install
-        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+    - gem install bundler -v '= 2.4.13'
+    # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
+    - cd /home && bundle install
+    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
-  - name: rocky-9-puppet-8
-    driver:
-      image: 'fannyatdd/docker-rocky9-systemd:test-9'
-      platform: rhel # kitchen-docker has issues installing packages otherwises
-      docker_platform: linux/amd64
-      privileged: true
-      use_cache: false
-      run_options: --cgroupns=host --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
-      run_command: /root/start.sh
-      provision_command:
-        - dnf module -y reset ruby
-        - dnf module -y enable ruby:3.1
-        - dnf module -y install ruby:3.1/common
+- name: rocky-9-puppet-8
+  driver:
+    image: 'datadog/docker-library:chef_kitchen_systemd_rocky_9'
+    platform: rhel # kitchen-docker has issues installing packages otherwises
+    docker_platform: linux/amd64
+    privileged: true
+    use_cache: false
+    run_options: --cgroupns=host --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw
+    run_command: /root/start.sh
+    provision_command:
+    - dnf module -y reset ruby
+    - dnf module -y enable ruby:3.1
+    - dnf module -y install ruby:3.1/common
 
-        - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
-        - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
-        - dnf group install -y "Development Tools"
-        - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
+    - rpm -Uvh https://yum.puppet.com/puppet8-release-el-9.noarch.rpm #installs the puppet-agent repo
+    - yum install -y puppet-agent-8.10.0 rubygems ruby-devel procps-ng
+    - dnf group install -y "Development Tools"
+    - ln -s /opt/puppetlabs/bin/puppet /usr/bin/puppet
 
-        - mkdir /home/kitchen/puppet -p
-        - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
-        - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
+    - mkdir /home/kitchen/puppet -p
+    - printf <%= File.read('environments/etc/Puppetfile').inspect %> > /home/kitchen/puppet/Puppetfile
+    - printf <%= File.read('environments/etc/Gemfile').inspect %> > /home/Gemfile
 
-        - gem install bundler -v '= 2.4.13'
-        # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
-        - cd /home && bundle install
-        - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
+    - gem install bundler -v '= 2.4.13'
+    # we use bundle to install gems and to lock dependencies versions of semantic_puppet and multipart-post
+    - cd /home && bundle install
+    - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
 #- name: opensuse/leap-15
 #  # Workaround for flakes on initializing opensuse/leap-15:
@@ -162,27 +162,27 @@ platforms:
 #      - cd /home/kitchen/puppet && r10k puppetfile install --moduledir=/tmp/modules
 
 suites:
-  - name: dd-agent
-    manifests: init.pp
-    verifier:
-      name: serverspec
-      default_pattern: true
-      additional_install_commmand: source /etc/profile.d/rvm.sh
-      env_vars:
-        TARGET_HOST: 127.0.0.1
-        TARGET_PORT: 2222
-        LOGIN_USER: root
-        LOGIN_PASSWORD: puppet
-  - name: dd-installer
-    manifests: init.pp
-    provisioner:
-      manifests_path: environments/etc/installer-manifests
-    verifier:
-      name: serverspec
-      default_pattern: true
-      additional_install_commmand: source /etc/profile.d/rvm.sh
-      env_vars:
-        TARGET_HOST: 127.0.0.1
-        TARGET_PORT: 2222
-        LOGIN_USER: root
-        LOGIN_PASSWORD: puppet
+- name: dd-agent
+  manifests: init.pp
+  verifier:
+    name: serverspec
+    default_pattern: true
+    additional_install_commmand: source /etc/profile.d/rvm.sh
+    env_vars:
+      TARGET_HOST: 127.0.0.1
+      TARGET_PORT: 2222
+      LOGIN_USER: root
+      LOGIN_PASSWORD: puppet
+- name: dd-installer
+  manifests: init.pp
+  provisioner:
+    manifests_path: environments/etc/installer-manifests
+  verifier:
+    name: serverspec
+    default_pattern: true
+    additional_install_commmand: source /etc/profile.d/rvm.sh
+    env_vars:
+      TARGET_HOST: 127.0.0.1
+      TARGET_PORT: 2222
+      LOGIN_USER: root
+      LOGIN_PASSWORD: puppet


### PR DESCRIPTION
### What does this PR do?

Use custom-built CentOS Stream 9 and Rocky Linux 9 docker images for kitchen tests.

CI: https://app.circleci.com/pipelines/github/DataDog/puppet-datadog-agent/1137/workflows/df161c72-9b03-45b9-9144-b3da21278e5c

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
