### PR TITLE
Fix postgres and elastic, agent 5 cleanups

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     stdlib:
-      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git" # TODO: why git: and not https:?
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "v9.7.0" # Puppet >= 7.0.0 < 9.0.0
     concat:
       repo: "https://github.com/puppetlabs/puppetlabs-concat.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,27 @@ Changes
 <!-- markdownlint-disable MD003 -->
 <!-- markdownlint-disable MD001 -->
 
-# 4.0.0 / 2025-02-28
+# 4.0.0 / 2025-03-07
 
-This release has multiple breaking changes, you may need to update your module integration; note that module dependencies has been updated.
+This release has multiple breaking changes, you may need to update your module integration; note that module
+dependencies has been updated.
 
-This release brings support for Puppet 8, which means all classes are now using defined class parameters types; this could break existing implementations.
+This release brings support for Puppet 8, which means all classes are now using defined class parameters types; this
+could break existing implementations.
 
 * [FEATURE] Add Support for Puppet 8 ([#779])
 * [FEATURE] Update Module Dependencies including updates for StdLib, migrating to newer functions where appropriate ([#800])
-* [FEATURE] Class definitions updated with references to DataDog examples
+* [FEATURE] Class definitions updated with references to Datadog examples
 * [FEATURE] Update to CI Builds to work with Ruby 3
 * [BUGFIX] Fix issue where MSI path was not correctly parsed ([#814])
 * [BUGFIX] BREAKING - `datadog_agent::integrations::disk` now expects booleans for `use_mount`, `all_partitions` and `tag_by_filesystem`
-* [DEPRECATE] Drop support for Datadog Agent version 5, including removal of unit tests
 * [DEPRECATE] Drop support for Puppet 6 and below
+* [DEPRECATE] Drop support for Datadog Agent version 5, including removal of unit tests
+* [DEPRECATE] Remove `ganglia`, `graphite`, `dogstreams`, `custom_emitters` and `use_curl_http_client` legacy configuration options which are no longer supported since Datadog Agent v6+
+* [DEPRECATE] Remove support for supplying a string to the `ssl_verify` option on the elasticsearch integration. We now use `tls_verify` which matches core Datadog code.
+* [DEPRECATE] Remove legacy Jenkins integration
+* [DEPRECATE] `skip_event` setting on TCP Check class has been removed from DataDog integration (removed since Datadog Agent v6.4+)
 * [DEPRECATE] Remove support for supplying a String to the `ssl_verify` option on the elasticsearch integration. Add updated `tls_*` options to match core Datadog code.
-* [DEPRECATE] Support for Jenkins integrations is removed
-* [DEPRECATE] `ganglia` configuration no longer supported as per DataDog Agent v6+
-* [DEPRECATE] `skip_event` setting on TCP Check class has been removed from DataDog integration
 
 # 3.24.0 / 2025-02-25
 
@@ -35,7 +38,8 @@ This release brings support for Puppet 8, which means all classes are now using 
 * [FEATURE] Add support for Datadog installer on Linux systems ([#820])
 * [DEPRECATE] Deprecate CentOS 6 to 7.51.1 maximum and install only relevant gpg keys on redhat based systems ([#806])
 * [SANITY] Remove a duplicate parameter in the documentation ([#799])(thanks [@albertollamaso])
-* [FEATURE] Allow defining `apm_filter_tags` and `apm_filter_tags_regex` to filter traces/spans ([#798])(thanks [@erik-frontify])
+* [FEATURE] Allow defining `apm_filter_tags` and `apm_filter_tags_regex` to filter traces/spans ([#798])(
+  thanks [@erik-frontify])
 
 # 3.22.0 / 2023-11-15
 
@@ -92,7 +96,8 @@ This release brings support for Puppet 8, which means all classes are now using 
 * [BUGFIX] Do not add process integration configuration file if not configured ([#703][]) (Thanks [@yanjunding][])
 * [FEATURE] add support for `min_collection_interval` for HTTP check ([#699][]) (Thanks [@yanjunding][])
 * [FEATURE] Improvements for APT keys management ([#698][], [#700][], [#701][] and [#714][])
-* [FEATURE] Include 'datadog_agent' class in the catalog when using the generic integration ([#697][]) (Thanks [@stantona][])
+* [FEATURE] Include 'datadog_agent' class in the catalog when using the generic integration ([#697][]) (
+  Thanks [@stantona][])
 * [BUGFIX] Update `excluded_interface_re` type to String ([#696][]) (Thanks [@florusboth][])
 
 # 3.12.0 / 2021-05-06
@@ -168,8 +173,10 @@ This release brings support for Puppet 8, which means all classes are now using 
 # 3.1.0 / 2020-01-14
 
 * [FEATURE] Accept the same version string in Debian/Ubuntu than in other OSes when pinning the Agent. See [#591][]
-* [FEATURE] Add the `check_hostname` and `ssl_server_name` parameters to the `http_check` integration. See [#599][] (Thanks [@asenci][])
-* [BUGFIX] Remove include from `system_probe.pp` that caused error "This Function Call is unacceptable as a top level construct in this location" on recent Puppet versions. See [#596][] (thanks again [@asenci][])
+* [FEATURE] Add the `check_hostname` and `ssl_server_name` parameters to the `http_check` integration. See [#599][] (
+  Thanks [@asenci][])
+* [BUGFIX] Remove include from `system_probe.pp` that caused error "This Function Call is unacceptable as a top level
+  construct in this location" on recent Puppet versions. See [#596][] (thanks again [@asenci][])
 * [BUGFIX] Fix broken `facts_to_tags` on Agent 5. See [#598][]
 * [CHORE] Migrate project to PDK (Puppet Development Kit). See [#597][]
 
@@ -225,8 +232,10 @@ then it is safe to upgrade.
 * [FEATURE] Initial Windows support. See [#557][]
 * [FEATURE] Add ignore_ssl_warning to HTTP check. See [#556][] (Thanks [@zabacad][])
 * [FEATURE] Add logs_open_files_limit parameter [#548][]. (Thanks [@rmrf-run][])
-* [BUGFIX] Fix a warning caused by calling `validate_legacy` with the default `additional_checksd` value of `undef`. See [#551][].
-* [BUGFIX] Fix Redis integration, where tags weren't evaluated when the keys param was empty. See [#558][] (Thanks [@jubagarie][])
+* [BUGFIX] Fix a warning caused by calling `validate_legacy` with the default `additional_checksd` value of `undef`.
+  See [#551][].
+* [BUGFIX] Fix Redis integration, where tags weren't evaluated when the keys param was empty. See [#558][] (
+  Thanks [@jubagarie][])
 * [DOCUMENTATION] Fix doc for HTTP check include_content. See [#555][] (Thanks [@zabacad][])
 
 # 2.7.0 / 2019-07-11
@@ -235,7 +244,8 @@ then it is safe to upgrade.
 
 * [FEATURE] Support puppet 6. See [#537][]
 * [FEATURE] Added a define that wraps the agent integration command. See [#534][]
-* [BUGFIX] Add whitespace surpression to redisdb.yaml.erb to ensure a valid yaml. See [#533][] (Thanks again [@Aramack][])
+* [BUGFIX] Add whitespace surpression to redisdb.yaml.erb to ensure a valid yaml. See [#533][] (Thanks
+  again [@Aramack][])
 * [BUGFIX] Do not include additional_checksd if not set. See [#545][] (Thanks [@turnopil][])
 * [IMPROVEMENT] Raise if hostname_extraction_regex doesn't capture hostname. See [#544][]
 
@@ -249,7 +259,8 @@ then it is safe to upgrade.
 * [FEATURE] Redis: adding multi-instance support. See [#520][]
 * [FEATURE] HTTP check: add support for `method`, `data` configuration. See [#515][] (Thanks [@Aramack][])
 * [FEATURE] HTTP check: add reverse content-match support. See [#524][] (Thanks [@dorg-kanderson][])
-* [BUGFIX] Agent 6: track integration configuration directories - fixes `conf_dir_purge`. See [#525][] (Thanks [@Aramack][])
+* [BUGFIX] Agent 6: track integration configuration directories - fixes `conf_dir_purge`. See [#525][] (
+  Thanks [@Aramack][])
 * [BUGFIX] Agent 6: fixes `additional_checksd` not appearing in agent config. See [#513][] (Thanks [@gotyaio][])
 * [BUGFIX] Postgres: allow setting password in Hiera. See [#514][] (Thanks [@cabrinha][])
 * [BUGFIX] Redis: fix trying to call `empty?` on an integer on template. See [#527][]
@@ -352,7 +363,8 @@ then it is safe to upgrade.
 * [BUGFIX] Stdlib: fix deprecations after stdlib 4.24.0. See [#403][] and [#404][] (Thanks [@teintuc][])
 * [BUGFIX] RHEL: stop specifying service resource provider `redhat`. See [#401][] (Thanks [@milescrabill][])
 * [IMPROVEMENT] Add types to multiple manifest parameters. See [#404][]
-* [COMPATIBILITY] Drop puppetlabs-apt dependency lower bound to `2.4.0`. See [#404][] and 400 (Thanks [@samueljamesmarshall][])
+* [COMPATIBILITY] Drop puppetlabs-apt dependency lower bound to `2.4.0`. See [#404][] and 400 (
+  Thanks [@samueljamesmarshall][])
 
 # 2.0.1 / 2018-02-28
 
@@ -383,7 +395,8 @@ Please read the [docs]() for more details.
 
 ### Notes
 
-* [MAJOR] Datadog agent defaults to 6.x. Puppet >=4.6. See [#387][] and [docs](https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md)
+* [MAJOR] Datadog agent defaults to 6.x. Puppet >=4.6. See [#387][]
+  and [docs](https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md)
 * [FEATURE] Postgresl: adding SSL parameter support. See [#391][] (thanks [@com6056][])
 * [FEATURE] Docker_daemon: parametrize integration. See [#378][] (thanks [@flyinprogrammer][])
 * [FEATURE] Kafka: added support for multiple instances. See [#343][], [#395][] (thanks [@jensendw][])
@@ -480,11 +493,13 @@ Please read the [docs]() for more details.
 * [BUGFIX] Reporting: allow the report processor to run on Puppet Enterprise. See [#266][]. (Thanks [@binford2k][]).
 * [BUGFIX] RHEL/CentOS: Fix gpg and test binary paths. See [#259][]. (Thanks [@sethcleveland][]).
 * [BUGFIX] NTP: fix template. See [#280][]. (Thanks [@MartinDelta][]).
-* [BUGFIX] Multiple integrations: swapped order of optional vs. non-optional parameters. See [#232][]. (Thanks [@sethcleveland][]).
+* [BUGFIX] Multiple integrations: swapped order of optional vs. non-optional parameters. See [#232][]. (
+  Thanks [@sethcleveland][]).
 
 * [IMPROVEMENT] [rpm+deb] repo keys rotated. See [#242][].
 * [IMPROVEMENT] MySQL: Allow multiple MySQL instances See [#267][]. (Thanks [@IanCrouch][]).
-* [IMPROVEMENT] Http check: `allow_redirects` + `check_certificate_expiration` improvement. See [#282][]. (Thanks [@cristianjuve][]).
+* [IMPROVEMENT] Http check: `allow_redirects` + `check_certificate_expiration` improvement. See [#282][]. (
+  Thanks [@cristianjuve][]).
 * [IMPROVEMENT] Http_check: update to include new attributes. See [#276][]. (Thanks [@aepod][]).
 * [IMPROVEMENT] Http_check: set disable_ssl_validation parameter. See [#258][].
 * [IMPROVEMENT] Postgres: support generic postgres custom metrics. See [#224][]. (Thanks [@sethcleveland][]).
@@ -552,18 +567,22 @@ Please read the [docs]() for more details.
 
 * [FEATURE] Added manifest for PGBouncer. See [#175][]. (Thanks [@mcasper][]).
 * [FEATURE] Added manifest for Consul. See [#174][]. (Thanks [@flyinprogrammer][]).
-* [FEATURE] Added mesos master and slave manifests for individual management. See [#174][]. (Thanks [@flyinprogrammer][] and [@jangie][]).
-* [FEATURE] Added option to extract the hostname from puppet hostname strings with a regex capture group. See [#173][]. (Thanks [@LeoCavaille][]).
+* [FEATURE] Added mesos master and slave manifests for individual management. See [#174][]. (Thanks [@flyinprogrammer][]
+  and [@jangie][]).
+* [FEATURE] Added option to extract the hostname from puppet hostname strings with a regex capture group.
+  See [#173][]. (Thanks [@LeoCavaille][]).
 * [FEATURE] Added support on multiple ports per host on Redis integration. See [#169][]. (Thanks [@fzwart][]).
 * [FEATURE] Added support for `disable_ssl_validation` on Apache integration. See[#171. (Thanks [@BIAndrews][]).
-* [FEATURE] Added support for SSL, additional metrics and database connection in Mongo integration. See [#164][]. (Thanks [@bflad][]).
+* [FEATURE] Added support for SSL, additional metrics and database connection in Mongo integration. See [#164][]. (
+  Thanks [@bflad][]).
 * [FEATURE] Added support for multiple instance in HTTP check. See [#155][]. (Thanks [@jniesen][]).
 * [FEATURE] Added support for multiple new datadog.conf directives. See [#79][]. (Thanks [@obowersa][]).
 * [FEATURE] Decouple yum repo from agent package. See [#168][]. (Thanks [@b2jrock][]).
 
 * [IMPROVEMENT] Moved GPG key to its own parameter. See [#158][]. (Thanks [@davidgibbons][]).
 
-* [BUFIX] Updated docker to use more current `docker_daemon`. See [#174][]. (Thanks [@flyinprogrammer][] and [@jangie][]).
+* [BUFIX] Updated docker to use more current `docker_daemon`. See [#174][]. (Thanks [@flyinprogrammer][]
+  and [@jangie][]).
 
 * [DEPRECATE] Deprecated old docker manifest. See [#174][]. (Thanks [@flyinprogrammer][]).
 * [DEPRECATE] Deprecated `new_tag_names` in `docker_daemon` manifest. See [#176][].
@@ -581,7 +600,8 @@ Please read the [docs]() for more details.
 
 * [BIGFIX] Use ensure_packages(), to be more polite about apt-transport-https. See [#154][]. (Thanks [@rtyler][]).
 * [BUGFIX] Fixed Zookeeper template. See [#150][] (Thanks [@tuxinaut][]).
-* [BUGFIX] Raised priority of `changed` event types to normal - they'll now show in Datadog UI. See [#156][]. (Thanks [@rtyler][]).
+* [BUGFIX] Raised priority of `changed` event types to normal - they'll now show in Datadog UI. See [#156][]. (
+  Thanks [@rtyler][]).
 * [BUGFIX] Require stdlib >=4.6 (provide `validate_integer()`). See [#161][]. (Thanks [@mrunkel-ut][]).
 
 * [CI] Testable up to puppet 4.2. See [#161][]. (Thanks [@grubernaut][]).
@@ -626,7 +646,7 @@ Please read the [docs]() for more details.
 * [FEATURE] Add `sock` parameter in MySQL integration
 * [FEATURE] Add support for graphite listener option in the main class
 * [FEATURE] Add NTP integration
-* [FEATURE] Add support for dogstreams array in the  main class
+* [FEATURE] Add support for dogstreams array in the main class
 * [FEATURE] Add HAProxy integration
 * [FEATURE] Add RabbitMQ integration
 * [FEATURE] Add support for an extra template appended to datadog.conf
@@ -651,7 +671,8 @@ Please read the [docs]() for more details.
 * [FEATURE] Add proxy options in the base datadog_agent class
 * [BUGFIX] Use correct JMX-styled tags in JMX integrations
 
-> Careful this means that you probably have to update a buggy array of tags (that gives you nothing in the agent) to a hash of tags.
+> Careful this means that you probably have to update a buggy array of tags (that gives you nothing in the agent) to a
+> hash of tags.
 
 * [BUGFIX] Fix ordering in YAML templates using `to_yaml` broken because of ruby 1.8
 * [CI] Add boilerpate for specs and linting rake tasks
@@ -680,418 +701,833 @@ Please read the [docs]() for more details.
 [docs]: https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md
 
 <!--- The following link definition list is generated by PimpMyChangelog --->
+
 [#79]: https://github.com/DataDog/puppet-datadog-agent/issues/79
+
 [#139]: https://github.com/DataDog/puppet-datadog-agent/issues/139
+
 [#145]: https://github.com/DataDog/puppet-datadog-agent/issues/145
+
 [#149]: https://github.com/DataDog/puppet-datadog-agent/issues/149
+
 [#150]: https://github.com/DataDog/puppet-datadog-agent/issues/150
+
 [#154]: https://github.com/DataDog/puppet-datadog-agent/issues/154
+
 [#155]: https://github.com/DataDog/puppet-datadog-agent/issues/155
+
 [#156]: https://github.com/DataDog/puppet-datadog-agent/issues/156
+
 [#158]: https://github.com/DataDog/puppet-datadog-agent/issues/158
+
 [#161]: https://github.com/DataDog/puppet-datadog-agent/issues/161
+
 [#164]: https://github.com/DataDog/puppet-datadog-agent/issues/164
+
 [#168]: https://github.com/DataDog/puppet-datadog-agent/issues/168
+
 [#169]: https://github.com/DataDog/puppet-datadog-agent/issues/169
+
 [#173]: https://github.com/DataDog/puppet-datadog-agent/issues/173
+
 [#174]: https://github.com/DataDog/puppet-datadog-agent/issues/174
+
 [#175]: https://github.com/DataDog/puppet-datadog-agent/issues/175
+
 [#176]: https://github.com/DataDog/puppet-datadog-agent/issues/176
+
 [#183]: https://github.com/DataDog/puppet-datadog-agent/issues/183
+
 [#186]: https://github.com/DataDog/puppet-datadog-agent/issues/186
+
 [#187]: https://github.com/DataDog/puppet-datadog-agent/issues/187
+
 [#188]: https://github.com/DataDog/puppet-datadog-agent/issues/188
+
 [#189]: https://github.com/DataDog/puppet-datadog-agent/issues/189
+
 [#195]: https://github.com/DataDog/puppet-datadog-agent/issues/195
+
 [#197]: https://github.com/DataDog/puppet-datadog-agent/issues/197
+
 [#202]: https://github.com/DataDog/puppet-datadog-agent/issues/202
+
 [#203]: https://github.com/DataDog/puppet-datadog-agent/issues/203
+
 [#204]: https://github.com/DataDog/puppet-datadog-agent/issues/204
+
 [#205]: https://github.com/DataDog/puppet-datadog-agent/issues/205
+
 [#207]: https://github.com/DataDog/puppet-datadog-agent/issues/207
+
 [#208]: https://github.com/DataDog/puppet-datadog-agent/issues/208
+
 [#209]: https://github.com/DataDog/puppet-datadog-agent/issues/209
+
 [#210]: https://github.com/DataDog/puppet-datadog-agent/issues/210
+
 [#211]: https://github.com/DataDog/puppet-datadog-agent/issues/211
+
 [#212]: https://github.com/DataDog/puppet-datadog-agent/issues/212
+
 [#213]: https://github.com/DataDog/puppet-datadog-agent/issues/213
+
 [#214]: https://github.com/DataDog/puppet-datadog-agent/issues/214
+
 [#215]: https://github.com/DataDog/puppet-datadog-agent/issues/215
+
 [#216]: https://github.com/DataDog/puppet-datadog-agent/issues/216
+
 [#217]: https://github.com/DataDog/puppet-datadog-agent/issues/217
+
 [#219]: https://github.com/DataDog/puppet-datadog-agent/issues/219
+
 [#222]: https://github.com/DataDog/puppet-datadog-agent/issues/222
+
 [#223]: https://github.com/DataDog/puppet-datadog-agent/issues/223
+
 [#224]: https://github.com/DataDog/puppet-datadog-agent/issues/224
+
 [#231]: https://github.com/DataDog/puppet-datadog-agent/issues/231
+
 [#232]: https://github.com/DataDog/puppet-datadog-agent/issues/232
+
 [#233]: https://github.com/DataDog/puppet-datadog-agent/issues/233
+
 [#242]: https://github.com/DataDog/puppet-datadog-agent/issues/242
+
 [#243]: https://github.com/DataDog/puppet-datadog-agent/issues/243
+
 [#247]: https://github.com/DataDog/puppet-datadog-agent/issues/247
+
 [#252]: https://github.com/DataDog/puppet-datadog-agent/issues/252
+
 [#256]: https://github.com/DataDog/puppet-datadog-agent/issues/256
+
 [#258]: https://github.com/DataDog/puppet-datadog-agent/issues/258
+
 [#259]: https://github.com/DataDog/puppet-datadog-agent/issues/259
+
 [#261]: https://github.com/DataDog/puppet-datadog-agent/issues/261
+
 [#263]: https://github.com/DataDog/puppet-datadog-agent/issues/263
+
 [#264]: https://github.com/DataDog/puppet-datadog-agent/issues/264
+
 [#266]: https://github.com/DataDog/puppet-datadog-agent/issues/266
+
 [#267]: https://github.com/DataDog/puppet-datadog-agent/issues/267
+
 [#276]: https://github.com/DataDog/puppet-datadog-agent/issues/276
+
 [#279]: https://github.com/DataDog/puppet-datadog-agent/issues/279
+
 [#280]: https://github.com/DataDog/puppet-datadog-agent/issues/280
+
 [#281]: https://github.com/DataDog/puppet-datadog-agent/issues/281
+
 [#282]: https://github.com/DataDog/puppet-datadog-agent/issues/282
+
 [#283]: https://github.com/DataDog/puppet-datadog-agent/issues/283
+
 [#286]: https://github.com/DataDog/puppet-datadog-agent/issues/286
+
 [#288]: https://github.com/DataDog/puppet-datadog-agent/issues/288
+
 [#290]: https://github.com/DataDog/puppet-datadog-agent/issues/290
+
 [#291]: https://github.com/DataDog/puppet-datadog-agent/issues/291
+
 [#292]: https://github.com/DataDog/puppet-datadog-agent/issues/292
+
 [#293]: https://github.com/DataDog/puppet-datadog-agent/issues/293
+
 [#296]: https://github.com/DataDog/puppet-datadog-agent/issues/296
+
 [#297]: https://github.com/DataDog/puppet-datadog-agent/issues/297
+
 [#299]: https://github.com/DataDog/puppet-datadog-agent/issues/299
+
 [#302]: https://github.com/DataDog/puppet-datadog-agent/issues/302
+
 [#309]: https://github.com/DataDog/puppet-datadog-agent/issues/309
+
 [#310]: https://github.com/DataDog/puppet-datadog-agent/issues/310
+
 [#311]: https://github.com/DataDog/puppet-datadog-agent/issues/311
+
 [#313]: https://github.com/DataDog/puppet-datadog-agent/issues/313
+
 [#315]: https://github.com/DataDog/puppet-datadog-agent/issues/315
+
 [#316]: https://github.com/DataDog/puppet-datadog-agent/issues/316
+
 [#318]: https://github.com/DataDog/puppet-datadog-agent/issues/318
+
 [#322]: https://github.com/DataDog/puppet-datadog-agent/issues/322
+
 [#323]: https://github.com/DataDog/puppet-datadog-agent/issues/323
+
 [#325]: https://github.com/DataDog/puppet-datadog-agent/issues/325
+
 [#326]: https://github.com/DataDog/puppet-datadog-agent/issues/326
+
 [#327]: https://github.com/DataDog/puppet-datadog-agent/issues/327
+
 [#329]: https://github.com/DataDog/puppet-datadog-agent/issues/329
+
 [#331]: https://github.com/DataDog/puppet-datadog-agent/issues/331
+
 [#332]: https://github.com/DataDog/puppet-datadog-agent/issues/332
+
 [#333]: https://github.com/DataDog/puppet-datadog-agent/issues/333
+
 [#334]: https://github.com/DataDog/puppet-datadog-agent/issues/334
+
 [#335]: https://github.com/DataDog/puppet-datadog-agent/issues/335
+
 [#336]: https://github.com/DataDog/puppet-datadog-agent/issues/336
+
 [#338]: https://github.com/DataDog/puppet-datadog-agent/issues/338
+
 [#340]: https://github.com/DataDog/puppet-datadog-agent/issues/340
+
 [#341]: https://github.com/DataDog/puppet-datadog-agent/issues/341
+
 [#343]: https://github.com/DataDog/puppet-datadog-agent/issues/343
+
 [#346]: https://github.com/DataDog/puppet-datadog-agent/issues/346
+
 [#347]: https://github.com/DataDog/puppet-datadog-agent/issues/347
+
 [#352]: https://github.com/DataDog/puppet-datadog-agent/issues/352
+
 [#356]: https://github.com/DataDog/puppet-datadog-agent/issues/356
+
 [#357]: https://github.com/DataDog/puppet-datadog-agent/issues/357
+
 [#359]: https://github.com/DataDog/puppet-datadog-agent/issues/359
+
 [#361]: https://github.com/DataDog/puppet-datadog-agent/issues/361
+
 [#362]: https://github.com/DataDog/puppet-datadog-agent/issues/362
+
 [#369]: https://github.com/DataDog/puppet-datadog-agent/issues/369
+
 [#370]: https://github.com/DataDog/puppet-datadog-agent/issues/370
+
 [#373]: https://github.com/DataDog/puppet-datadog-agent/issues/373
+
 [#374]: https://github.com/DataDog/puppet-datadog-agent/issues/374
+
 [#375]: https://github.com/DataDog/puppet-datadog-agent/issues/375
+
 [#376]: https://github.com/DataDog/puppet-datadog-agent/issues/376
+
 [#377]: https://github.com/DataDog/puppet-datadog-agent/issues/377
+
 [#378]: https://github.com/DataDog/puppet-datadog-agent/issues/378
+
 [#379]: https://github.com/DataDog/puppet-datadog-agent/issues/379
+
 [#381]: https://github.com/DataDog/puppet-datadog-agent/issues/381
+
 [#384]: https://github.com/DataDog/puppet-datadog-agent/issues/384
+
 [#387]: https://github.com/DataDog/puppet-datadog-agent/issues/387
+
 [#389]: https://github.com/DataDog/puppet-datadog-agent/issues/389
+
 [#390]: https://github.com/DataDog/puppet-datadog-agent/issues/390
+
 [#391]: https://github.com/DataDog/puppet-datadog-agent/issues/391
+
 [#394]: https://github.com/DataDog/puppet-datadog-agent/issues/394
+
 [#395]: https://github.com/DataDog/puppet-datadog-agent/issues/395
+
 [#397]: https://github.com/DataDog/puppet-datadog-agent/issues/397
+
 [#401]: https://github.com/DataDog/puppet-datadog-agent/issues/401
+
 [#403]: https://github.com/DataDog/puppet-datadog-agent/issues/403
+
 [#404]: https://github.com/DataDog/puppet-datadog-agent/issues/404
+
 [#406]: https://github.com/DataDog/puppet-datadog-agent/issues/406
+
 [#408]: https://github.com/DataDog/puppet-datadog-agent/issues/408
+
 [#411]: https://github.com/DataDog/puppet-datadog-agent/issues/411
+
 [#412]: https://github.com/DataDog/puppet-datadog-agent/issues/412
+
 [#417]: https://github.com/DataDog/puppet-datadog-agent/issues/417
+
 [#418]: https://github.com/DataDog/puppet-datadog-agent/issues/418
+
 [#420]: https://github.com/DataDog/puppet-datadog-agent/issues/420
+
 [#424]: https://github.com/DataDog/puppet-datadog-agent/issues/424
+
 [#426]: https://github.com/DataDog/puppet-datadog-agent/issues/426
+
 [#427]: https://github.com/DataDog/puppet-datadog-agent/issues/427
+
 [#431]: https://github.com/DataDog/puppet-datadog-agent/issues/431
+
 [#433]: https://github.com/DataDog/puppet-datadog-agent/issues/433
+
 [#437]: https://github.com/DataDog/puppet-datadog-agent/issues/437
+
 [#438]: https://github.com/DataDog/puppet-datadog-agent/issues/438
+
 [#439]: https://github.com/DataDog/puppet-datadog-agent/issues/439
+
 [#443]: https://github.com/DataDog/puppet-datadog-agent/issues/443
+
 [#444]: https://github.com/DataDog/puppet-datadog-agent/issues/444
+
 [#445]: https://github.com/DataDog/puppet-datadog-agent/issues/445
+
 [#446]: https://github.com/DataDog/puppet-datadog-agent/issues/446
+
 [#449]: https://github.com/DataDog/puppet-datadog-agent/issues/449
+
 [#455]: https://github.com/DataDog/puppet-datadog-agent/issues/455
+
 [#462]: https://github.com/DataDog/puppet-datadog-agent/issues/462
+
 [#463]: https://github.com/DataDog/puppet-datadog-agent/issues/463
+
 [#464]: https://github.com/DataDog/puppet-datadog-agent/issues/464
+
 [#466]: https://github.com/DataDog/puppet-datadog-agent/issues/466
+
 [#468]: https://github.com/DataDog/puppet-datadog-agent/issues/468
+
 [#470]: https://github.com/DataDog/puppet-datadog-agent/issues/470
+
 [#471]: https://github.com/DataDog/puppet-datadog-agent/issues/471
+
 [#472]: https://github.com/DataDog/puppet-datadog-agent/issues/472
+
 [#473]: https://github.com/DataDog/puppet-datadog-agent/issues/473
+
 [#475]: https://github.com/DataDog/puppet-datadog-agent/issues/475
+
 [#481]: https://github.com/DataDog/puppet-datadog-agent/issues/481
+
 [#482]: https://github.com/DataDog/puppet-datadog-agent/issues/482
+
 [#484]: https://github.com/DataDog/puppet-datadog-agent/issues/484
+
 [#485]: https://github.com/DataDog/puppet-datadog-agent/issues/485
+
 [#486]: https://github.com/DataDog/puppet-datadog-agent/issues/486
+
 [#487]: https://github.com/DataDog/puppet-datadog-agent/issues/487
+
 [#490]: https://github.com/DataDog/puppet-datadog-agent/issues/490
+
 [#492]: https://github.com/DataDog/puppet-datadog-agent/issues/492
+
 [#493]: https://github.com/DataDog/puppet-datadog-agent/issues/493
+
 [#496]: https://github.com/DataDog/puppet-datadog-agent/issues/496
+
 [#498]: https://github.com/DataDog/puppet-datadog-agent/issues/498
+
 [#501]: https://github.com/DataDog/puppet-datadog-agent/issues/501
+
 [#502]: https://github.com/DataDog/puppet-datadog-agent/issues/502
+
 [#503]: https://github.com/DataDog/puppet-datadog-agent/issues/503
+
 [#504]: https://github.com/DataDog/puppet-datadog-agent/issues/504
+
 [#506]: https://github.com/DataDog/puppet-datadog-agent/issues/506
+
 [#507]: https://github.com/DataDog/puppet-datadog-agent/issues/507
+
 [#508]: https://github.com/DataDog/puppet-datadog-agent/issues/508
+
 [#511]: https://github.com/DataDog/puppet-datadog-agent/issues/511
+
 [#513]: https://github.com/DataDog/puppet-datadog-agent/issues/513
+
 [#514]: https://github.com/DataDog/puppet-datadog-agent/issues/514
+
 [#515]: https://github.com/DataDog/puppet-datadog-agent/issues/515
+
 [#516]: https://github.com/DataDog/puppet-datadog-agent/issues/516
+
 [#519]: https://github.com/DataDog/puppet-datadog-agent/issues/519
+
 [#520]: https://github.com/DataDog/puppet-datadog-agent/issues/520
+
 [#521]: https://github.com/DataDog/puppet-datadog-agent/issues/521
+
 [#524]: https://github.com/DataDog/puppet-datadog-agent/issues/524
+
 [#525]: https://github.com/DataDog/puppet-datadog-agent/issues/525
+
 [#527]: https://github.com/DataDog/puppet-datadog-agent/issues/527
+
 [#528]: https://github.com/DataDog/puppet-datadog-agent/issues/528
+
 [#533]: https://github.com/DataDog/puppet-datadog-agent/issues/533
+
 [#534]: https://github.com/DataDog/puppet-datadog-agent/issues/534
+
 [#537]: https://github.com/DataDog/puppet-datadog-agent/issues/537
+
 [#544]: https://github.com/DataDog/puppet-datadog-agent/issues/544
+
 [#545]: https://github.com/DataDog/puppet-datadog-agent/issues/545
+
 [#548]: https://github.com/DataDog/puppet-datadog-agent/issues/548
+
 [#551]: https://github.com/DataDog/puppet-datadog-agent/issues/551
+
 [#555]: https://github.com/DataDog/puppet-datadog-agent/issues/555
+
 [#556]: https://github.com/DataDog/puppet-datadog-agent/issues/556
+
 [#557]: https://github.com/DataDog/puppet-datadog-agent/issues/557
+
 [#558]: https://github.com/DataDog/puppet-datadog-agent/issues/558
+
 [#562]: https://github.com/DataDog/puppet-datadog-agent/issues/562
+
 [#571]: https://github.com/DataDog/puppet-datadog-agent/issues/571
+
 [#572]: https://github.com/DataDog/puppet-datadog-agent/issues/572
+
 [#574]: https://github.com/DataDog/puppet-datadog-agent/issues/574
+
 [#576]: https://github.com/DataDog/puppet-datadog-agent/issues/576
+
 [#578]: https://github.com/DataDog/puppet-datadog-agent/issues/578
+
 [#581]: https://github.com/DataDog/puppet-datadog-agent/issues/581
+
 [#584]: https://github.com/DataDog/puppet-datadog-agent/issues/584
+
 [#587]: https://github.com/DataDog/puppet-datadog-agent/issues/587
+
 [#588]: https://github.com/DataDog/puppet-datadog-agent/issues/588
+
 [#591]: https://github.com/DataDog/puppet-datadog-agent/issues/591
+
 [#596]: https://github.com/DataDog/puppet-datadog-agent/issues/596
+
 [#597]: https://github.com/DataDog/puppet-datadog-agent/issues/597
+
 [#598]: https://github.com/DataDog/puppet-datadog-agent/issues/598
+
 [#599]: https://github.com/DataDog/puppet-datadog-agent/issues/599
+
 [#608]: https://github.com/DataDog/puppet-datadog-agent/issues/608
+
 [#613]: https://github.com/DataDog/puppet-datadog-agent/issues/613
+
 [#615]: https://github.com/DataDog/puppet-datadog-agent/issues/615
+
 [#616]: https://github.com/DataDog/puppet-datadog-agent/issues/616
+
 [#621]: https://github.com/DataDog/puppet-datadog-agent/issues/621
+
 [#622]: https://github.com/DataDog/puppet-datadog-agent/issues/622
+
 [#624]: https://github.com/DataDog/puppet-datadog-agent/issues/624
+
 [#626]: https://github.com/DataDog/puppet-datadog-agent/issues/626
+
 [#628]: https://github.com/DataDog/puppet-datadog-agent/issues/628
+
 [#630]: https://github.com/DataDog/puppet-datadog-agent/issues/630
+
 [#633]: https://github.com/DataDog/puppet-datadog-agent/issues/633
+
 [#636]: https://github.com/DataDog/puppet-datadog-agent/issues/636
+
 [#639]: https://github.com/DataDog/puppet-datadog-agent/issues/639
+
 [#641]: https://github.com/DataDog/puppet-datadog-agent/issues/641
+
 [#643]: https://github.com/DataDog/puppet-datadog-agent/issues/643
+
 [#653]: https://github.com/DataDog/puppet-datadog-agent/issues/653
+
 [#654]: https://github.com/DataDog/puppet-datadog-agent/issues/654
+
 [#656]: https://github.com/DataDog/puppet-datadog-agent/issues/656
+
 [#658]: https://github.com/DataDog/puppet-datadog-agent/issues/658
+
 [#661]: https://github.com/DataDog/puppet-datadog-agent/issues/661
+
 [#662]: https://github.com/DataDog/puppet-datadog-agent/issues/662
+
 [#664]: https://github.com/DataDog/puppet-datadog-agent/issues/664
+
 [#666]: https://github.com/DataDog/puppet-datadog-agent/issues/666
+
 [#667]: https://github.com/DataDog/puppet-datadog-agent/issues/667
+
 [#672]: https://github.com/DataDog/puppet-datadog-agent/issues/672
+
 [#675]: https://github.com/DataDog/puppet-datadog-agent/issues/675
+
 [#677]: https://github.com/DataDog/puppet-datadog-agent/issues/677
+
 [#679]: https://github.com/DataDog/puppet-datadog-agent/issues/679
+
 [#681]: https://github.com/DataDog/puppet-datadog-agent/issues/681
+
 [#682]: https://github.com/DataDog/puppet-datadog-agent/issues/682
+
 [#686]: https://github.com/DataDog/puppet-datadog-agent/issues/686
+
 [#687]: https://github.com/DataDog/puppet-datadog-agent/issues/687
+
 [#688]: https://github.com/DataDog/puppet-datadog-agent/issues/688
+
 [#690]: https://github.com/DataDog/puppet-datadog-agent/issues/690
+
 [#692]: https://github.com/DataDog/puppet-datadog-agent/issues/692
+
 [#693]: https://github.com/DataDog/puppet-datadog-agent/issues/693
+
 [#696]: https://github.com/DataDog/puppet-datadog-agent/issues/696
+
 [#697]: https://github.com/DataDog/puppet-datadog-agent/issues/697
+
 [#698]: https://github.com/DataDog/puppet-datadog-agent/issues/698
+
 [#699]: https://github.com/DataDog/puppet-datadog-agent/issues/699
+
 [#700]: https://github.com/DataDog/puppet-datadog-agent/issues/700
+
 [#701]: https://github.com/DataDog/puppet-datadog-agent/issues/701
+
 [#703]: https://github.com/DataDog/puppet-datadog-agent/issues/703
+
 [#706]: https://github.com/DataDog/puppet-datadog-agent/issues/706
+
 [#709]: https://github.com/DataDog/puppet-datadog-agent/issues/709
+
 [#712]: https://github.com/DataDog/puppet-datadog-agent/issues/712
+
 [#714]: https://github.com/DataDog/puppet-datadog-agent/issues/714
+
 [#719]: https://github.com/DataDog/puppet-datadog-agent/issues/719
+
 [#721]: https://github.com/DataDog/puppet-datadog-agent/issues/721
+
 [#725]: https://github.com/DataDog/puppet-datadog-agent/issues/725
+
 [#726]: https://github.com/DataDog/puppet-datadog-agent/issues/726
+
 [#728]: https://github.com/DataDog/puppet-datadog-agent/issues/728
+
 [#732]: https://github.com/DataDog/puppet-datadog-agent/issues/732
+
 [#733]: https://github.com/DataDog/puppet-datadog-agent/issues/733
+
 [#741]: https://github.com/DataDog/puppet-datadog-agent/issues/741
+
 [#746]: https://github.com/DataDog/puppet-datadog-agent/issues/746
+
 [#748]: https://github.com/DataDog/puppet-datadog-agent/issues/748
+
 [#751]: https://github.com/DataDog/puppet-datadog-agent/issues/751
+
 [#752]: https://github.com/DataDog/puppet-datadog-agent/issues/752
+
 [#755]: https://github.com/DataDog/puppet-datadog-agent/issues/755
+
 [#756]: https://github.com/DataDog/puppet-datadog-agent/issues/756
+
 [#761]: https://github.com/DataDog/puppet-datadog-agent/issues/761
+
 [#770]: https://github.com/DataDog/puppet-datadog-agent/issues/770
+
 [#779]: https://github.com/DataDog/puppet-datadog-agent/issues/779
+
 [#782]: https://github.com/DataDog/puppet-datadog-agent/issues/782
+
 [#785]: https://github.com/DataDog/puppet-datadog-agent/issues/785
+
 [#789]: https://github.com/DataDog/puppet-datadog-agent/issues/789
+
 [#790]: https://github.com/DataDog/puppet-datadog-agent/issues/790
+
 [#798]: https://github.com/DataDog/puppet-datadog-agent/issues/798
+
 [#799]: https://github.com/DataDog/puppet-datadog-agent/issues/799
+
 [#800]: https://github.com/DataDog/puppet-datadog-agent/issues/800
+
 [#806]: https://github.com/DataDog/puppet-datadog-agent/issues/806
+
 [#814]: https://github.com/DataDog/puppet-datadog-agent/issues/814
+
 [#820]: https://github.com/DataDog/puppet-datadog-agent/issues/820
+
 [#821]: https://github.com/DataDog/puppet-datadog-agent/issues/821
+
 [#824]: https://github.com/DataDog/puppet-datadog-agent/issues/824
+
 [#835]: https://github.com/DataDog/puppet-datadog-agent/issues/835
+
 [@Aramack]: https://github.com/Aramack
+
 [@BIAndrews]: https://github.com/BIAndrews
+
 [@ChannoneArif-nbcuni]: https://github.com/ChannoneArif-nbcuni
+
 [@ColinHebert]: https://github.com/ColinHebert
+
 [@ColinHerbert]: https://github.com/ColinHerbert
+
 [@DDRBoxman]: https://github.com/DDRBoxman
+
 [@IanCrouch]: https://github.com/IanCrouch
+
 [@LeoCavaille]: https://github.com/LeoCavaille
+
 [@MartinDelta]: https://github.com/MartinDelta
+
 [@Mstrodl]: https://github.com/Mstrodl
+
 [@NoodlesNZ]: https://github.com/NoodlesNZ
+
 [@aaron-miller]: https://github.com/aaron-miller
+
 [@aepod]: https://github.com/aepod
+
 [@ajvb]: https://github.com/ajvb
+
 [@albertollamaso]: https://github.com/albertollamaso
+
 [@alexberry]: https://github.com/alexberry
+
 [@alexfouche]: https://github.com/alexfouche
+
 [@alexharv074]: https://github.com/alexharv074
+
 [@alvin-huang]: https://github.com/alvin-huang
+
 [@ardichoke]: https://github.com/ardichoke
+
 [@arkpoah]: https://github.com/arkpoah
+
 [@asenci]: https://github.com/asenci
+
 [@atayts]: https://github.com/atayts
+
 [@b2jrock]: https://github.com/b2jrock
+
 [@bflad]: https://github.com/bflad
+
 [@binford2k]: https://github.com/binford2k
+
 [@bit-herder]: https://github.com/bit-herder
+
 [@bittner]: https://github.com/bittner
+
 [@butangero]: https://github.com/butangero
+
 [@cabrinha]: https://github.com/cabrinha
+
 [@charles-ferguson]: https://github.com/charles-ferguson
+
 [@ckolos]: https://github.com/ckolos
+
 [@cocker-cc]: https://github.com/cocker-cc
+
 [@com6056]: https://github.com/com6056
+
 [@craigwatson]: https://github.com/craigwatson
+
 [@cristianjuve]: https://github.com/cristianjuve
+
 [@cwood]: https://github.com/cwood
+
 [@damonmaria]: https://github.com/damonmaria
+
 [@dan70402]: https://github.com/dan70402
+
 [@davejrt]: https://github.com/davejrt
+
 [@davidgibbons]: https://github.com/davidgibbons
+
 [@dbednall]: https://github.com/dbednall
+
 [@degemer]: https://github.com/degemer
+
 [@denmat]: https://github.com/denmat
+
 [@devinmatte]: https://github.com/devinmatte
+
 [@diogokiss]: https://github.com/diogokiss
+
 [@djova]: https://github.com/djova
+
 [@dorg-kanderson]: https://github.com/dorg-kanderson
+
 [@dpricha89]: https://github.com/dpricha89
+
 [@dschaaff]: https://github.com/dschaaff
+
 [@dzinek]: https://github.com/dzinek
+
 [@eddmann]: https://github.com/eddmann
+
 [@erik-frontify]: https://github.com/erik-frontify
+
 [@evansj]: https://github.com/evansj
+
 [@ewansteele]: https://github.com/ewansteele
+
 [@ffleming]: https://github.com/ffleming
+
 [@ffrants]: https://github.com/ffrants
+
 [@florusboth]: https://github.com/florusboth
+
 [@flyinbutrs]: https://github.com/flyinbutrs
+
 [@flyinprogrammer]: https://github.com/flyinprogrammer
+
 [@fr3nd]: https://github.com/fr3nd
+
 [@fwelschen]: https://github.com/fwelschen
+
 [@fzwart]: https://github.com/fzwart
+
 [@generica]: https://github.com/generica
+
 [@gotyaio]: https://github.com/gotyaio
+
 [@grubernaut]: https://github.com/grubernaut
+
 [@jabbate19]: https://github.com/jabbate19
+
 [@jacobbednarz]: https://github.com/jacobbednarz
+
 [@jadams-av]: https://github.com/jadams-av
+
 [@jameynelson]: https://github.com/jameynelson
+
 [@jangie]: https://github.com/jangie
+
 [@jcarr-sailthru]: https://github.com/jcarr-sailthru
+
 [@jdavisp3]: https://github.com/jdavisp3
+
 [@jensendw]: https://github.com/jensendw
+
 [@jfrost]: https://github.com/jfrost
+
 [@jniesen]: https://github.com/jniesen
+
 [@jubagarie]: https://github.com/jubagarie
+
 [@jvanbrunschot]: https://github.com/jvanbrunschot
+
 [@kevin-bowers]: https://github.com/kevin-bowers
+
 [@kitchen]: https://github.com/kitchen
+
 [@lowkeyshift]: https://github.com/lowkeyshift
+
 [@mcasper]: https://github.com/mcasper
+
 [@milescrabill]: https://github.com/milescrabill
+
 [@mraylu]: https://github.com/mraylu
+
 [@mrunkel-ut]: https://github.com/mrunkel-ut
+
 [@mtougeron]: https://github.com/mtougeron
+
 [@murdok5]: https://github.com/murdok5
+
 [@npaufler]: https://github.com/npaufler
+
 [@o0oxid]: https://github.com/o0oxid
+
 [@obi11235]: https://github.com/obi11235
+
 [@obowersa]: https://github.com/obowersa
+
 [@oshmyrko]: https://github.com/oshmyrko
+
 [@pabrahamsson]: https://github.com/pabrahamsson
+
 [@paulhamby]: https://github.com/paulhamby
+
 [@pid1]: https://github.com/pid1
+
 [@pulkitsethi]: https://github.com/pulkitsethi
+
 [@rgergo]: https://github.com/rgergo
+
 [@rmrf-run]: https://github.com/rmrf-run
+
 [@rooprob]: https://github.com/rooprob
+
 [@rothgar]: https://github.com/rothgar
+
 [@rtyler]: https://github.com/rtyler
+
 [@rud]: https://github.com/rud
+
 [@ryan-dyer-sp]: https://github.com/ryan-dyer-sp
+
 [@sambanks]: https://github.com/sambanks
+
 [@samueljamesmarshall]: https://github.com/samueljamesmarshall
+
 [@scottgeary]: https://github.com/scottgeary
+
 [@sethcleveland]: https://github.com/sethcleveland
+
 [@siebrand]: https://github.com/siebrand
+
 [@skiedude]: https://github.com/skiedude
+
 [@spectralblu]: https://github.com/spectralblu
+
 [@stamak]: https://github.com/stamak
+
 [@stantona]: https://github.com/stantona
+
 [@swwolf]: https://github.com/swwolf
+
 [@szponek]: https://github.com/szponek
+
 [@tdm4]: https://github.com/tdm4
+
 [@teintuc]: https://github.com/teintuc
+
 [@tommoyangn]: https://github.com/tommoyangn
+
 [@turnopil]: https://github.com/turnopil
+
 [@tuxinaut]: https://github.com/tuxinaut
+
 [@vaisingh]: https://github.com/vaisingh
+
 [@yanjunding]: https://github.com/yanjunding
+
 [@yrcjaya]: https://github.com/yrcjaya
+
 [@zabacad]: https://github.com/zabacad
+
 [@zickzackv]: https://github.com/zickzackv
+
 [@zoom-kris-anderson]: https://github.com/zoom-kris-anderson

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,10 @@ This release brings support for Puppet 8, which means all classes are now using 
 * [BUGFIX] BREAKING - `datadog_agent::integrations::disk` now expects booleans for `use_mount`, `all_partitions` and `tag_by_filesystem`
 * [DEPRECATE] Drop support for Datadog Agent version 5, including removal of unit tests
 * [DEPRECATE] Drop support for Puppet 6 and below
-* [DEPRECATE] Remove support for supply a String to the SSL_Verify option on the elasticsearch integration. We now use tls_verify which matches core DataDog code.
+* [DEPRECATE] Remove support for supplying a String to the `ssl_verify` option on the elasticsearch integration. Add updated `tls_*` options to match core Datadog code.
 * [DEPRECATE] Support for Jenkins integrations is removed
-* [DEPRECATE] No longer possible to use the custom metrics parameter when using the PostgresSQL class
 * [DEPRECATE] `ganglia` configuration no longer supported as per DataDog Agent v6+
 * [DEPRECATE] `skip_event` setting on TCP Check class has been removed from DataDog integration
-* [DEPRECATE] Postgres implementation now only accepts booleans for `ssl` settings.
 
 # 3.24.0 / 2025-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,7 @@ could break existing implementations.
 * [FEATURE] Add support for Datadog installer on Linux systems ([#820])
 * [DEPRECATE] Deprecate CentOS 6 to 7.51.1 maximum and install only relevant gpg keys on redhat based systems ([#806])
 * [SANITY] Remove a duplicate parameter in the documentation ([#799])(thanks [@albertollamaso])
-* [FEATURE] Allow defining `apm_filter_tags` and `apm_filter_tags_regex` to filter traces/spans ([#798])(
-  thanks [@erik-frontify])
+* [FEATURE] Allow defining `apm_filter_tags` and `apm_filter_tags_regex` to filter traces/spans ([#798])(thanks [@erik-frontify])
 
 # 3.22.0 / 2023-11-15
 
@@ -96,8 +95,7 @@ could break existing implementations.
 * [BUGFIX] Do not add process integration configuration file if not configured ([#703][]) (Thanks [@yanjunding][])
 * [FEATURE] add support for `min_collection_interval` for HTTP check ([#699][]) (Thanks [@yanjunding][])
 * [FEATURE] Improvements for APT keys management ([#698][], [#700][], [#701][] and [#714][])
-* [FEATURE] Include 'datadog_agent' class in the catalog when using the generic integration ([#697][]) (
-  Thanks [@stantona][])
+* [FEATURE] Include 'datadog_agent' class in the catalog when using the generic integration ([#697][]) (Thanks [@stantona][])
 * [BUGFIX] Update `excluded_interface_re` type to String ([#696][]) (Thanks [@florusboth][])
 
 # 3.12.0 / 2021-05-06
@@ -173,10 +171,8 @@ could break existing implementations.
 # 3.1.0 / 2020-01-14
 
 * [FEATURE] Accept the same version string in Debian/Ubuntu than in other OSes when pinning the Agent. See [#591][]
-* [FEATURE] Add the `check_hostname` and `ssl_server_name` parameters to the `http_check` integration. See [#599][] (
-  Thanks [@asenci][])
-* [BUGFIX] Remove include from `system_probe.pp` that caused error "This Function Call is unacceptable as a top level
-  construct in this location" on recent Puppet versions. See [#596][] (thanks again [@asenci][])
+* [FEATURE] Add the `check_hostname` and `ssl_server_name` parameters to the `http_check` integration. See [#599][] (Thanks [@asenci][])
+* [BUGFIX] Remove include from `system_probe.pp` that caused error "This Function Call is unacceptable as a top level construct in this location" on recent Puppet versions. See [#596][] (thanks again [@asenci][])
 * [BUGFIX] Fix broken `facts_to_tags` on Agent 5. See [#598][]
 * [CHORE] Migrate project to PDK (Puppet Development Kit). See [#597][]
 
@@ -232,10 +228,8 @@ then it is safe to upgrade.
 * [FEATURE] Initial Windows support. See [#557][]
 * [FEATURE] Add ignore_ssl_warning to HTTP check. See [#556][] (Thanks [@zabacad][])
 * [FEATURE] Add logs_open_files_limit parameter [#548][]. (Thanks [@rmrf-run][])
-* [BUGFIX] Fix a warning caused by calling `validate_legacy` with the default `additional_checksd` value of `undef`.
-  See [#551][].
-* [BUGFIX] Fix Redis integration, where tags weren't evaluated when the keys param was empty. See [#558][] (
-  Thanks [@jubagarie][])
+* [BUGFIX] Fix a warning caused by calling `validate_legacy` with the default `additional_checksd` value of `undef`. See [#551][].
+* [BUGFIX] Fix Redis integration, where tags weren't evaluated when the keys param was empty. See [#558][] (Thanks [@jubagarie][])
 * [DOCUMENTATION] Fix doc for HTTP check include_content. See [#555][] (Thanks [@zabacad][])
 
 # 2.7.0 / 2019-07-11
@@ -244,8 +238,7 @@ then it is safe to upgrade.
 
 * [FEATURE] Support puppet 6. See [#537][]
 * [FEATURE] Added a define that wraps the agent integration command. See [#534][]
-* [BUGFIX] Add whitespace surpression to redisdb.yaml.erb to ensure a valid yaml. See [#533][] (Thanks
-  again [@Aramack][])
+* [BUGFIX] Add whitespace surpression to redisdb.yaml.erb to ensure a valid yaml. See [#533][] (Thanks again [@Aramack][])
 * [BUGFIX] Do not include additional_checksd if not set. See [#545][] (Thanks [@turnopil][])
 * [IMPROVEMENT] Raise if hostname_extraction_regex doesn't capture hostname. See [#544][]
 
@@ -259,8 +252,7 @@ then it is safe to upgrade.
 * [FEATURE] Redis: adding multi-instance support. See [#520][]
 * [FEATURE] HTTP check: add support for `method`, `data` configuration. See [#515][] (Thanks [@Aramack][])
 * [FEATURE] HTTP check: add reverse content-match support. See [#524][] (Thanks [@dorg-kanderson][])
-* [BUGFIX] Agent 6: track integration configuration directories - fixes `conf_dir_purge`. See [#525][] (
-  Thanks [@Aramack][])
+* [BUGFIX] Agent 6: track integration configuration directories - fixes `conf_dir_purge`. See [#525][] (Thanks [@Aramack][])
 * [BUGFIX] Agent 6: fixes `additional_checksd` not appearing in agent config. See [#513][] (Thanks [@gotyaio][])
 * [BUGFIX] Postgres: allow setting password in Hiera. See [#514][] (Thanks [@cabrinha][])
 * [BUGFIX] Redis: fix trying to call `empty?` on an integer on template. See [#527][]
@@ -363,8 +355,7 @@ then it is safe to upgrade.
 * [BUGFIX] Stdlib: fix deprecations after stdlib 4.24.0. See [#403][] and [#404][] (Thanks [@teintuc][])
 * [BUGFIX] RHEL: stop specifying service resource provider `redhat`. See [#401][] (Thanks [@milescrabill][])
 * [IMPROVEMENT] Add types to multiple manifest parameters. See [#404][]
-* [COMPATIBILITY] Drop puppetlabs-apt dependency lower bound to `2.4.0`. See [#404][] and 400 (
-  Thanks [@samueljamesmarshall][])
+* [COMPATIBILITY] Drop puppetlabs-apt dependency lower bound to `2.4.0`. See [#404][] and 400 (Thanks [@samueljamesmarshall][])
 
 # 2.0.1 / 2018-02-28
 
@@ -395,8 +386,7 @@ Please read the [docs]() for more details.
 
 ### Notes
 
-* [MAJOR] Datadog agent defaults to 6.x. Puppet >=4.6. See [#387][]
-  and [docs](https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md)
+* [MAJOR] Datadog agent defaults to 6.x. Puppet >=4.6. See [#387][] and [docs](https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md)
 * [FEATURE] Postgresl: adding SSL parameter support. See [#391][] (thanks [@com6056][])
 * [FEATURE] Docker_daemon: parametrize integration. See [#378][] (thanks [@flyinprogrammer][])
 * [FEATURE] Kafka: added support for multiple instances. See [#343][], [#395][] (thanks [@jensendw][])
@@ -493,13 +483,11 @@ Please read the [docs]() for more details.
 * [BUGFIX] Reporting: allow the report processor to run on Puppet Enterprise. See [#266][]. (Thanks [@binford2k][]).
 * [BUGFIX] RHEL/CentOS: Fix gpg and test binary paths. See [#259][]. (Thanks [@sethcleveland][]).
 * [BUGFIX] NTP: fix template. See [#280][]. (Thanks [@MartinDelta][]).
-* [BUGFIX] Multiple integrations: swapped order of optional vs. non-optional parameters. See [#232][]. (
-  Thanks [@sethcleveland][]).
+* [BUGFIX] Multiple integrations: swapped order of optional vs. non-optional parameters. See [#232][]. (Thanks [@sethcleveland][]).
 
 * [IMPROVEMENT] [rpm+deb] repo keys rotated. See [#242][].
 * [IMPROVEMENT] MySQL: Allow multiple MySQL instances See [#267][]. (Thanks [@IanCrouch][]).
-* [IMPROVEMENT] Http check: `allow_redirects` + `check_certificate_expiration` improvement. See [#282][]. (
-  Thanks [@cristianjuve][]).
+* [IMPROVEMENT] Http check: `allow_redirects` + `check_certificate_expiration` improvement. See [#282][]. (Thanks [@cristianjuve][]).
 * [IMPROVEMENT] Http_check: update to include new attributes. See [#276][]. (Thanks [@aepod][]).
 * [IMPROVEMENT] Http_check: set disable_ssl_validation parameter. See [#258][].
 * [IMPROVEMENT] Postgres: support generic postgres custom metrics. See [#224][]. (Thanks [@sethcleveland][]).
@@ -567,22 +555,18 @@ Please read the [docs]() for more details.
 
 * [FEATURE] Added manifest for PGBouncer. See [#175][]. (Thanks [@mcasper][]).
 * [FEATURE] Added manifest for Consul. See [#174][]. (Thanks [@flyinprogrammer][]).
-* [FEATURE] Added mesos master and slave manifests for individual management. See [#174][]. (Thanks [@flyinprogrammer][]
-  and [@jangie][]).
-* [FEATURE] Added option to extract the hostname from puppet hostname strings with a regex capture group.
-  See [#173][]. (Thanks [@LeoCavaille][]).
+* [FEATURE] Added mesos master and slave manifests for individual management. See [#174][]. (Thanks [@flyinprogrammer][] and [@jangie][]).
+* [FEATURE] Added option to extract the hostname from puppet hostname strings with a regex capture group. See [#173][]. (Thanks [@LeoCavaille][]).
 * [FEATURE] Added support on multiple ports per host on Redis integration. See [#169][]. (Thanks [@fzwart][]).
 * [FEATURE] Added support for `disable_ssl_validation` on Apache integration. See[#171. (Thanks [@BIAndrews][]).
-* [FEATURE] Added support for SSL, additional metrics and database connection in Mongo integration. See [#164][]. (
-  Thanks [@bflad][]).
+* [FEATURE] Added support for SSL, additional metrics and database connection in Mongo integration. See [#164][]. (Thanks [@bflad][]).
 * [FEATURE] Added support for multiple instance in HTTP check. See [#155][]. (Thanks [@jniesen][]).
 * [FEATURE] Added support for multiple new datadog.conf directives. See [#79][]. (Thanks [@obowersa][]).
 * [FEATURE] Decouple yum repo from agent package. See [#168][]. (Thanks [@b2jrock][]).
 
 * [IMPROVEMENT] Moved GPG key to its own parameter. See [#158][]. (Thanks [@davidgibbons][]).
 
-* [BUFIX] Updated docker to use more current `docker_daemon`. See [#174][]. (Thanks [@flyinprogrammer][]
-  and [@jangie][]).
+* [BUFIX] Updated docker to use more current `docker_daemon`. See [#174][]. (Thanks [@flyinprogrammer][] and [@jangie][]).
 
 * [DEPRECATE] Deprecated old docker manifest. See [#174][]. (Thanks [@flyinprogrammer][]).
 * [DEPRECATE] Deprecated `new_tag_names` in `docker_daemon` manifest. See [#176][].
@@ -600,8 +584,7 @@ Please read the [docs]() for more details.
 
 * [BIGFIX] Use ensure_packages(), to be more polite about apt-transport-https. See [#154][]. (Thanks [@rtyler][]).
 * [BUGFIX] Fixed Zookeeper template. See [#150][] (Thanks [@tuxinaut][]).
-* [BUGFIX] Raised priority of `changed` event types to normal - they'll now show in Datadog UI. See [#156][]. (
-  Thanks [@rtyler][]).
+* [BUGFIX] Raised priority of `changed` event types to normal - they'll now show in Datadog UI. See [#156][]. (Thanks [@rtyler][]).
 * [BUGFIX] Require stdlib >=4.6 (provide `validate_integer()`). See [#161][]. (Thanks [@mrunkel-ut][]).
 
 * [CI] Testable up to puppet 4.2. See [#161][]. (Thanks [@grubernaut][]).
@@ -646,7 +629,7 @@ Please read the [docs]() for more details.
 * [FEATURE] Add `sock` parameter in MySQL integration
 * [FEATURE] Add support for graphite listener option in the main class
 * [FEATURE] Add NTP integration
-* [FEATURE] Add support for dogstreams array in the main class
+* [FEATURE] Add support for dogstreams array in the  main class
 * [FEATURE] Add HAProxy integration
 * [FEATURE] Add RabbitMQ integration
 * [FEATURE] Add support for an extra template appended to datadog.conf
@@ -671,8 +654,7 @@ Please read the [docs]() for more details.
 * [FEATURE] Add proxy options in the base datadog_agent class
 * [BUGFIX] Use correct JMX-styled tags in JMX integrations
 
-> Careful this means that you probably have to update a buggy array of tags (that gives you nothing in the agent) to a
-> hash of tags.
+> Careful this means that you probably have to update a buggy array of tags (that gives you nothing in the agent) to a hash of tags.
 
 * [BUGFIX] Fix ordering in YAML templates using `to_yaml` broken because of ruby 1.8
 * [CI] Add boilerpate for specs and linting rake tasks
@@ -701,833 +683,418 @@ Please read the [docs]() for more details.
 [docs]: https://github.com/DataDog/puppet-datadog-agent/blob/master/README.md
 
 <!--- The following link definition list is generated by PimpMyChangelog --->
-
 [#79]: https://github.com/DataDog/puppet-datadog-agent/issues/79
-
 [#139]: https://github.com/DataDog/puppet-datadog-agent/issues/139
-
 [#145]: https://github.com/DataDog/puppet-datadog-agent/issues/145
-
 [#149]: https://github.com/DataDog/puppet-datadog-agent/issues/149
-
 [#150]: https://github.com/DataDog/puppet-datadog-agent/issues/150
-
 [#154]: https://github.com/DataDog/puppet-datadog-agent/issues/154
-
 [#155]: https://github.com/DataDog/puppet-datadog-agent/issues/155
-
 [#156]: https://github.com/DataDog/puppet-datadog-agent/issues/156
-
 [#158]: https://github.com/DataDog/puppet-datadog-agent/issues/158
-
 [#161]: https://github.com/DataDog/puppet-datadog-agent/issues/161
-
 [#164]: https://github.com/DataDog/puppet-datadog-agent/issues/164
-
 [#168]: https://github.com/DataDog/puppet-datadog-agent/issues/168
-
 [#169]: https://github.com/DataDog/puppet-datadog-agent/issues/169
-
 [#173]: https://github.com/DataDog/puppet-datadog-agent/issues/173
-
 [#174]: https://github.com/DataDog/puppet-datadog-agent/issues/174
-
 [#175]: https://github.com/DataDog/puppet-datadog-agent/issues/175
-
 [#176]: https://github.com/DataDog/puppet-datadog-agent/issues/176
-
 [#183]: https://github.com/DataDog/puppet-datadog-agent/issues/183
-
 [#186]: https://github.com/DataDog/puppet-datadog-agent/issues/186
-
 [#187]: https://github.com/DataDog/puppet-datadog-agent/issues/187
-
 [#188]: https://github.com/DataDog/puppet-datadog-agent/issues/188
-
 [#189]: https://github.com/DataDog/puppet-datadog-agent/issues/189
-
 [#195]: https://github.com/DataDog/puppet-datadog-agent/issues/195
-
 [#197]: https://github.com/DataDog/puppet-datadog-agent/issues/197
-
 [#202]: https://github.com/DataDog/puppet-datadog-agent/issues/202
-
 [#203]: https://github.com/DataDog/puppet-datadog-agent/issues/203
-
 [#204]: https://github.com/DataDog/puppet-datadog-agent/issues/204
-
 [#205]: https://github.com/DataDog/puppet-datadog-agent/issues/205
-
 [#207]: https://github.com/DataDog/puppet-datadog-agent/issues/207
-
 [#208]: https://github.com/DataDog/puppet-datadog-agent/issues/208
-
 [#209]: https://github.com/DataDog/puppet-datadog-agent/issues/209
-
 [#210]: https://github.com/DataDog/puppet-datadog-agent/issues/210
-
 [#211]: https://github.com/DataDog/puppet-datadog-agent/issues/211
-
 [#212]: https://github.com/DataDog/puppet-datadog-agent/issues/212
-
 [#213]: https://github.com/DataDog/puppet-datadog-agent/issues/213
-
 [#214]: https://github.com/DataDog/puppet-datadog-agent/issues/214
-
 [#215]: https://github.com/DataDog/puppet-datadog-agent/issues/215
-
 [#216]: https://github.com/DataDog/puppet-datadog-agent/issues/216
-
 [#217]: https://github.com/DataDog/puppet-datadog-agent/issues/217
-
 [#219]: https://github.com/DataDog/puppet-datadog-agent/issues/219
-
 [#222]: https://github.com/DataDog/puppet-datadog-agent/issues/222
-
 [#223]: https://github.com/DataDog/puppet-datadog-agent/issues/223
-
 [#224]: https://github.com/DataDog/puppet-datadog-agent/issues/224
-
 [#231]: https://github.com/DataDog/puppet-datadog-agent/issues/231
-
 [#232]: https://github.com/DataDog/puppet-datadog-agent/issues/232
-
 [#233]: https://github.com/DataDog/puppet-datadog-agent/issues/233
-
 [#242]: https://github.com/DataDog/puppet-datadog-agent/issues/242
-
 [#243]: https://github.com/DataDog/puppet-datadog-agent/issues/243
-
 [#247]: https://github.com/DataDog/puppet-datadog-agent/issues/247
-
 [#252]: https://github.com/DataDog/puppet-datadog-agent/issues/252
-
 [#256]: https://github.com/DataDog/puppet-datadog-agent/issues/256
-
 [#258]: https://github.com/DataDog/puppet-datadog-agent/issues/258
-
 [#259]: https://github.com/DataDog/puppet-datadog-agent/issues/259
-
 [#261]: https://github.com/DataDog/puppet-datadog-agent/issues/261
-
 [#263]: https://github.com/DataDog/puppet-datadog-agent/issues/263
-
 [#264]: https://github.com/DataDog/puppet-datadog-agent/issues/264
-
 [#266]: https://github.com/DataDog/puppet-datadog-agent/issues/266
-
 [#267]: https://github.com/DataDog/puppet-datadog-agent/issues/267
-
 [#276]: https://github.com/DataDog/puppet-datadog-agent/issues/276
-
 [#279]: https://github.com/DataDog/puppet-datadog-agent/issues/279
-
 [#280]: https://github.com/DataDog/puppet-datadog-agent/issues/280
-
 [#281]: https://github.com/DataDog/puppet-datadog-agent/issues/281
-
 [#282]: https://github.com/DataDog/puppet-datadog-agent/issues/282
-
 [#283]: https://github.com/DataDog/puppet-datadog-agent/issues/283
-
 [#286]: https://github.com/DataDog/puppet-datadog-agent/issues/286
-
 [#288]: https://github.com/DataDog/puppet-datadog-agent/issues/288
-
 [#290]: https://github.com/DataDog/puppet-datadog-agent/issues/290
-
 [#291]: https://github.com/DataDog/puppet-datadog-agent/issues/291
-
 [#292]: https://github.com/DataDog/puppet-datadog-agent/issues/292
-
 [#293]: https://github.com/DataDog/puppet-datadog-agent/issues/293
-
 [#296]: https://github.com/DataDog/puppet-datadog-agent/issues/296
-
 [#297]: https://github.com/DataDog/puppet-datadog-agent/issues/297
-
 [#299]: https://github.com/DataDog/puppet-datadog-agent/issues/299
-
 [#302]: https://github.com/DataDog/puppet-datadog-agent/issues/302
-
 [#309]: https://github.com/DataDog/puppet-datadog-agent/issues/309
-
 [#310]: https://github.com/DataDog/puppet-datadog-agent/issues/310
-
 [#311]: https://github.com/DataDog/puppet-datadog-agent/issues/311
-
 [#313]: https://github.com/DataDog/puppet-datadog-agent/issues/313
-
 [#315]: https://github.com/DataDog/puppet-datadog-agent/issues/315
-
 [#316]: https://github.com/DataDog/puppet-datadog-agent/issues/316
-
 [#318]: https://github.com/DataDog/puppet-datadog-agent/issues/318
-
 [#322]: https://github.com/DataDog/puppet-datadog-agent/issues/322
-
 [#323]: https://github.com/DataDog/puppet-datadog-agent/issues/323
-
 [#325]: https://github.com/DataDog/puppet-datadog-agent/issues/325
-
 [#326]: https://github.com/DataDog/puppet-datadog-agent/issues/326
-
 [#327]: https://github.com/DataDog/puppet-datadog-agent/issues/327
-
 [#329]: https://github.com/DataDog/puppet-datadog-agent/issues/329
-
 [#331]: https://github.com/DataDog/puppet-datadog-agent/issues/331
-
 [#332]: https://github.com/DataDog/puppet-datadog-agent/issues/332
-
 [#333]: https://github.com/DataDog/puppet-datadog-agent/issues/333
-
 [#334]: https://github.com/DataDog/puppet-datadog-agent/issues/334
-
 [#335]: https://github.com/DataDog/puppet-datadog-agent/issues/335
-
 [#336]: https://github.com/DataDog/puppet-datadog-agent/issues/336
-
 [#338]: https://github.com/DataDog/puppet-datadog-agent/issues/338
-
 [#340]: https://github.com/DataDog/puppet-datadog-agent/issues/340
-
 [#341]: https://github.com/DataDog/puppet-datadog-agent/issues/341
-
 [#343]: https://github.com/DataDog/puppet-datadog-agent/issues/343
-
 [#346]: https://github.com/DataDog/puppet-datadog-agent/issues/346
-
 [#347]: https://github.com/DataDog/puppet-datadog-agent/issues/347
-
 [#352]: https://github.com/DataDog/puppet-datadog-agent/issues/352
-
 [#356]: https://github.com/DataDog/puppet-datadog-agent/issues/356
-
 [#357]: https://github.com/DataDog/puppet-datadog-agent/issues/357
-
 [#359]: https://github.com/DataDog/puppet-datadog-agent/issues/359
-
 [#361]: https://github.com/DataDog/puppet-datadog-agent/issues/361
-
 [#362]: https://github.com/DataDog/puppet-datadog-agent/issues/362
-
 [#369]: https://github.com/DataDog/puppet-datadog-agent/issues/369
-
 [#370]: https://github.com/DataDog/puppet-datadog-agent/issues/370
-
 [#373]: https://github.com/DataDog/puppet-datadog-agent/issues/373
-
 [#374]: https://github.com/DataDog/puppet-datadog-agent/issues/374
-
 [#375]: https://github.com/DataDog/puppet-datadog-agent/issues/375
-
 [#376]: https://github.com/DataDog/puppet-datadog-agent/issues/376
-
 [#377]: https://github.com/DataDog/puppet-datadog-agent/issues/377
-
 [#378]: https://github.com/DataDog/puppet-datadog-agent/issues/378
-
 [#379]: https://github.com/DataDog/puppet-datadog-agent/issues/379
-
 [#381]: https://github.com/DataDog/puppet-datadog-agent/issues/381
-
 [#384]: https://github.com/DataDog/puppet-datadog-agent/issues/384
-
 [#387]: https://github.com/DataDog/puppet-datadog-agent/issues/387
-
 [#389]: https://github.com/DataDog/puppet-datadog-agent/issues/389
-
 [#390]: https://github.com/DataDog/puppet-datadog-agent/issues/390
-
 [#391]: https://github.com/DataDog/puppet-datadog-agent/issues/391
-
 [#394]: https://github.com/DataDog/puppet-datadog-agent/issues/394
-
 [#395]: https://github.com/DataDog/puppet-datadog-agent/issues/395
-
 [#397]: https://github.com/DataDog/puppet-datadog-agent/issues/397
-
 [#401]: https://github.com/DataDog/puppet-datadog-agent/issues/401
-
 [#403]: https://github.com/DataDog/puppet-datadog-agent/issues/403
-
 [#404]: https://github.com/DataDog/puppet-datadog-agent/issues/404
-
 [#406]: https://github.com/DataDog/puppet-datadog-agent/issues/406
-
 [#408]: https://github.com/DataDog/puppet-datadog-agent/issues/408
-
 [#411]: https://github.com/DataDog/puppet-datadog-agent/issues/411
-
 [#412]: https://github.com/DataDog/puppet-datadog-agent/issues/412
-
 [#417]: https://github.com/DataDog/puppet-datadog-agent/issues/417
-
 [#418]: https://github.com/DataDog/puppet-datadog-agent/issues/418
-
 [#420]: https://github.com/DataDog/puppet-datadog-agent/issues/420
-
 [#424]: https://github.com/DataDog/puppet-datadog-agent/issues/424
-
 [#426]: https://github.com/DataDog/puppet-datadog-agent/issues/426
-
 [#427]: https://github.com/DataDog/puppet-datadog-agent/issues/427
-
 [#431]: https://github.com/DataDog/puppet-datadog-agent/issues/431
-
 [#433]: https://github.com/DataDog/puppet-datadog-agent/issues/433
-
 [#437]: https://github.com/DataDog/puppet-datadog-agent/issues/437
-
 [#438]: https://github.com/DataDog/puppet-datadog-agent/issues/438
-
 [#439]: https://github.com/DataDog/puppet-datadog-agent/issues/439
-
 [#443]: https://github.com/DataDog/puppet-datadog-agent/issues/443
-
 [#444]: https://github.com/DataDog/puppet-datadog-agent/issues/444
-
 [#445]: https://github.com/DataDog/puppet-datadog-agent/issues/445
-
 [#446]: https://github.com/DataDog/puppet-datadog-agent/issues/446
-
 [#449]: https://github.com/DataDog/puppet-datadog-agent/issues/449
-
 [#455]: https://github.com/DataDog/puppet-datadog-agent/issues/455
-
 [#462]: https://github.com/DataDog/puppet-datadog-agent/issues/462
-
 [#463]: https://github.com/DataDog/puppet-datadog-agent/issues/463
-
 [#464]: https://github.com/DataDog/puppet-datadog-agent/issues/464
-
 [#466]: https://github.com/DataDog/puppet-datadog-agent/issues/466
-
 [#468]: https://github.com/DataDog/puppet-datadog-agent/issues/468
-
 [#470]: https://github.com/DataDog/puppet-datadog-agent/issues/470
-
 [#471]: https://github.com/DataDog/puppet-datadog-agent/issues/471
-
 [#472]: https://github.com/DataDog/puppet-datadog-agent/issues/472
-
 [#473]: https://github.com/DataDog/puppet-datadog-agent/issues/473
-
 [#475]: https://github.com/DataDog/puppet-datadog-agent/issues/475
-
 [#481]: https://github.com/DataDog/puppet-datadog-agent/issues/481
-
 [#482]: https://github.com/DataDog/puppet-datadog-agent/issues/482
-
 [#484]: https://github.com/DataDog/puppet-datadog-agent/issues/484
-
 [#485]: https://github.com/DataDog/puppet-datadog-agent/issues/485
-
 [#486]: https://github.com/DataDog/puppet-datadog-agent/issues/486
-
 [#487]: https://github.com/DataDog/puppet-datadog-agent/issues/487
-
 [#490]: https://github.com/DataDog/puppet-datadog-agent/issues/490
-
 [#492]: https://github.com/DataDog/puppet-datadog-agent/issues/492
-
 [#493]: https://github.com/DataDog/puppet-datadog-agent/issues/493
-
 [#496]: https://github.com/DataDog/puppet-datadog-agent/issues/496
-
 [#498]: https://github.com/DataDog/puppet-datadog-agent/issues/498
-
 [#501]: https://github.com/DataDog/puppet-datadog-agent/issues/501
-
 [#502]: https://github.com/DataDog/puppet-datadog-agent/issues/502
-
 [#503]: https://github.com/DataDog/puppet-datadog-agent/issues/503
-
 [#504]: https://github.com/DataDog/puppet-datadog-agent/issues/504
-
 [#506]: https://github.com/DataDog/puppet-datadog-agent/issues/506
-
 [#507]: https://github.com/DataDog/puppet-datadog-agent/issues/507
-
 [#508]: https://github.com/DataDog/puppet-datadog-agent/issues/508
-
 [#511]: https://github.com/DataDog/puppet-datadog-agent/issues/511
-
 [#513]: https://github.com/DataDog/puppet-datadog-agent/issues/513
-
 [#514]: https://github.com/DataDog/puppet-datadog-agent/issues/514
-
 [#515]: https://github.com/DataDog/puppet-datadog-agent/issues/515
-
 [#516]: https://github.com/DataDog/puppet-datadog-agent/issues/516
-
 [#519]: https://github.com/DataDog/puppet-datadog-agent/issues/519
-
 [#520]: https://github.com/DataDog/puppet-datadog-agent/issues/520
-
 [#521]: https://github.com/DataDog/puppet-datadog-agent/issues/521
-
 [#524]: https://github.com/DataDog/puppet-datadog-agent/issues/524
-
 [#525]: https://github.com/DataDog/puppet-datadog-agent/issues/525
-
 [#527]: https://github.com/DataDog/puppet-datadog-agent/issues/527
-
 [#528]: https://github.com/DataDog/puppet-datadog-agent/issues/528
-
 [#533]: https://github.com/DataDog/puppet-datadog-agent/issues/533
-
 [#534]: https://github.com/DataDog/puppet-datadog-agent/issues/534
-
 [#537]: https://github.com/DataDog/puppet-datadog-agent/issues/537
-
 [#544]: https://github.com/DataDog/puppet-datadog-agent/issues/544
-
 [#545]: https://github.com/DataDog/puppet-datadog-agent/issues/545
-
 [#548]: https://github.com/DataDog/puppet-datadog-agent/issues/548
-
 [#551]: https://github.com/DataDog/puppet-datadog-agent/issues/551
-
 [#555]: https://github.com/DataDog/puppet-datadog-agent/issues/555
-
 [#556]: https://github.com/DataDog/puppet-datadog-agent/issues/556
-
 [#557]: https://github.com/DataDog/puppet-datadog-agent/issues/557
-
 [#558]: https://github.com/DataDog/puppet-datadog-agent/issues/558
-
 [#562]: https://github.com/DataDog/puppet-datadog-agent/issues/562
-
 [#571]: https://github.com/DataDog/puppet-datadog-agent/issues/571
-
 [#572]: https://github.com/DataDog/puppet-datadog-agent/issues/572
-
 [#574]: https://github.com/DataDog/puppet-datadog-agent/issues/574
-
 [#576]: https://github.com/DataDog/puppet-datadog-agent/issues/576
-
 [#578]: https://github.com/DataDog/puppet-datadog-agent/issues/578
-
 [#581]: https://github.com/DataDog/puppet-datadog-agent/issues/581
-
 [#584]: https://github.com/DataDog/puppet-datadog-agent/issues/584
-
 [#587]: https://github.com/DataDog/puppet-datadog-agent/issues/587
-
 [#588]: https://github.com/DataDog/puppet-datadog-agent/issues/588
-
 [#591]: https://github.com/DataDog/puppet-datadog-agent/issues/591
-
 [#596]: https://github.com/DataDog/puppet-datadog-agent/issues/596
-
 [#597]: https://github.com/DataDog/puppet-datadog-agent/issues/597
-
 [#598]: https://github.com/DataDog/puppet-datadog-agent/issues/598
-
 [#599]: https://github.com/DataDog/puppet-datadog-agent/issues/599
-
 [#608]: https://github.com/DataDog/puppet-datadog-agent/issues/608
-
 [#613]: https://github.com/DataDog/puppet-datadog-agent/issues/613
-
 [#615]: https://github.com/DataDog/puppet-datadog-agent/issues/615
-
 [#616]: https://github.com/DataDog/puppet-datadog-agent/issues/616
-
 [#621]: https://github.com/DataDog/puppet-datadog-agent/issues/621
-
 [#622]: https://github.com/DataDog/puppet-datadog-agent/issues/622
-
 [#624]: https://github.com/DataDog/puppet-datadog-agent/issues/624
-
 [#626]: https://github.com/DataDog/puppet-datadog-agent/issues/626
-
 [#628]: https://github.com/DataDog/puppet-datadog-agent/issues/628
-
 [#630]: https://github.com/DataDog/puppet-datadog-agent/issues/630
-
 [#633]: https://github.com/DataDog/puppet-datadog-agent/issues/633
-
 [#636]: https://github.com/DataDog/puppet-datadog-agent/issues/636
-
 [#639]: https://github.com/DataDog/puppet-datadog-agent/issues/639
-
 [#641]: https://github.com/DataDog/puppet-datadog-agent/issues/641
-
 [#643]: https://github.com/DataDog/puppet-datadog-agent/issues/643
-
 [#653]: https://github.com/DataDog/puppet-datadog-agent/issues/653
-
 [#654]: https://github.com/DataDog/puppet-datadog-agent/issues/654
-
 [#656]: https://github.com/DataDog/puppet-datadog-agent/issues/656
-
 [#658]: https://github.com/DataDog/puppet-datadog-agent/issues/658
-
 [#661]: https://github.com/DataDog/puppet-datadog-agent/issues/661
-
 [#662]: https://github.com/DataDog/puppet-datadog-agent/issues/662
-
 [#664]: https://github.com/DataDog/puppet-datadog-agent/issues/664
-
 [#666]: https://github.com/DataDog/puppet-datadog-agent/issues/666
-
 [#667]: https://github.com/DataDog/puppet-datadog-agent/issues/667
-
 [#672]: https://github.com/DataDog/puppet-datadog-agent/issues/672
-
 [#675]: https://github.com/DataDog/puppet-datadog-agent/issues/675
-
 [#677]: https://github.com/DataDog/puppet-datadog-agent/issues/677
-
 [#679]: https://github.com/DataDog/puppet-datadog-agent/issues/679
-
 [#681]: https://github.com/DataDog/puppet-datadog-agent/issues/681
-
 [#682]: https://github.com/DataDog/puppet-datadog-agent/issues/682
-
 [#686]: https://github.com/DataDog/puppet-datadog-agent/issues/686
-
 [#687]: https://github.com/DataDog/puppet-datadog-agent/issues/687
-
 [#688]: https://github.com/DataDog/puppet-datadog-agent/issues/688
-
 [#690]: https://github.com/DataDog/puppet-datadog-agent/issues/690
-
 [#692]: https://github.com/DataDog/puppet-datadog-agent/issues/692
-
 [#693]: https://github.com/DataDog/puppet-datadog-agent/issues/693
-
 [#696]: https://github.com/DataDog/puppet-datadog-agent/issues/696
-
 [#697]: https://github.com/DataDog/puppet-datadog-agent/issues/697
-
 [#698]: https://github.com/DataDog/puppet-datadog-agent/issues/698
-
 [#699]: https://github.com/DataDog/puppet-datadog-agent/issues/699
-
 [#700]: https://github.com/DataDog/puppet-datadog-agent/issues/700
-
 [#701]: https://github.com/DataDog/puppet-datadog-agent/issues/701
-
 [#703]: https://github.com/DataDog/puppet-datadog-agent/issues/703
-
 [#706]: https://github.com/DataDog/puppet-datadog-agent/issues/706
-
 [#709]: https://github.com/DataDog/puppet-datadog-agent/issues/709
-
 [#712]: https://github.com/DataDog/puppet-datadog-agent/issues/712
-
 [#714]: https://github.com/DataDog/puppet-datadog-agent/issues/714
-
 [#719]: https://github.com/DataDog/puppet-datadog-agent/issues/719
-
 [#721]: https://github.com/DataDog/puppet-datadog-agent/issues/721
-
 [#725]: https://github.com/DataDog/puppet-datadog-agent/issues/725
-
 [#726]: https://github.com/DataDog/puppet-datadog-agent/issues/726
-
 [#728]: https://github.com/DataDog/puppet-datadog-agent/issues/728
-
 [#732]: https://github.com/DataDog/puppet-datadog-agent/issues/732
-
 [#733]: https://github.com/DataDog/puppet-datadog-agent/issues/733
-
 [#741]: https://github.com/DataDog/puppet-datadog-agent/issues/741
-
 [#746]: https://github.com/DataDog/puppet-datadog-agent/issues/746
-
 [#748]: https://github.com/DataDog/puppet-datadog-agent/issues/748
-
 [#751]: https://github.com/DataDog/puppet-datadog-agent/issues/751
-
 [#752]: https://github.com/DataDog/puppet-datadog-agent/issues/752
-
 [#755]: https://github.com/DataDog/puppet-datadog-agent/issues/755
-
 [#756]: https://github.com/DataDog/puppet-datadog-agent/issues/756
-
 [#761]: https://github.com/DataDog/puppet-datadog-agent/issues/761
-
 [#770]: https://github.com/DataDog/puppet-datadog-agent/issues/770
-
 [#779]: https://github.com/DataDog/puppet-datadog-agent/issues/779
-
 [#782]: https://github.com/DataDog/puppet-datadog-agent/issues/782
-
 [#785]: https://github.com/DataDog/puppet-datadog-agent/issues/785
-
 [#789]: https://github.com/DataDog/puppet-datadog-agent/issues/789
-
 [#790]: https://github.com/DataDog/puppet-datadog-agent/issues/790
-
 [#798]: https://github.com/DataDog/puppet-datadog-agent/issues/798
-
 [#799]: https://github.com/DataDog/puppet-datadog-agent/issues/799
-
 [#800]: https://github.com/DataDog/puppet-datadog-agent/issues/800
-
 [#806]: https://github.com/DataDog/puppet-datadog-agent/issues/806
-
 [#814]: https://github.com/DataDog/puppet-datadog-agent/issues/814
-
 [#820]: https://github.com/DataDog/puppet-datadog-agent/issues/820
-
 [#821]: https://github.com/DataDog/puppet-datadog-agent/issues/821
-
 [#824]: https://github.com/DataDog/puppet-datadog-agent/issues/824
-
 [#835]: https://github.com/DataDog/puppet-datadog-agent/issues/835
-
 [@Aramack]: https://github.com/Aramack
-
 [@BIAndrews]: https://github.com/BIAndrews
-
 [@ChannoneArif-nbcuni]: https://github.com/ChannoneArif-nbcuni
-
 [@ColinHebert]: https://github.com/ColinHebert
-
 [@ColinHerbert]: https://github.com/ColinHerbert
-
 [@DDRBoxman]: https://github.com/DDRBoxman
-
 [@IanCrouch]: https://github.com/IanCrouch
-
 [@LeoCavaille]: https://github.com/LeoCavaille
-
 [@MartinDelta]: https://github.com/MartinDelta
-
 [@Mstrodl]: https://github.com/Mstrodl
-
 [@NoodlesNZ]: https://github.com/NoodlesNZ
-
 [@aaron-miller]: https://github.com/aaron-miller
-
 [@aepod]: https://github.com/aepod
-
 [@ajvb]: https://github.com/ajvb
-
 [@albertollamaso]: https://github.com/albertollamaso
-
 [@alexberry]: https://github.com/alexberry
-
 [@alexfouche]: https://github.com/alexfouche
-
 [@alexharv074]: https://github.com/alexharv074
-
 [@alvin-huang]: https://github.com/alvin-huang
-
 [@ardichoke]: https://github.com/ardichoke
-
 [@arkpoah]: https://github.com/arkpoah
-
 [@asenci]: https://github.com/asenci
-
 [@atayts]: https://github.com/atayts
-
 [@b2jrock]: https://github.com/b2jrock
-
 [@bflad]: https://github.com/bflad
-
 [@binford2k]: https://github.com/binford2k
-
 [@bit-herder]: https://github.com/bit-herder
-
 [@bittner]: https://github.com/bittner
-
 [@butangero]: https://github.com/butangero
-
 [@cabrinha]: https://github.com/cabrinha
-
 [@charles-ferguson]: https://github.com/charles-ferguson
-
 [@ckolos]: https://github.com/ckolos
-
 [@cocker-cc]: https://github.com/cocker-cc
-
 [@com6056]: https://github.com/com6056
-
 [@craigwatson]: https://github.com/craigwatson
-
 [@cristianjuve]: https://github.com/cristianjuve
-
 [@cwood]: https://github.com/cwood
-
 [@damonmaria]: https://github.com/damonmaria
-
 [@dan70402]: https://github.com/dan70402
-
 [@davejrt]: https://github.com/davejrt
-
 [@davidgibbons]: https://github.com/davidgibbons
-
 [@dbednall]: https://github.com/dbednall
-
 [@degemer]: https://github.com/degemer
-
 [@denmat]: https://github.com/denmat
-
 [@devinmatte]: https://github.com/devinmatte
-
 [@diogokiss]: https://github.com/diogokiss
-
 [@djova]: https://github.com/djova
-
 [@dorg-kanderson]: https://github.com/dorg-kanderson
-
 [@dpricha89]: https://github.com/dpricha89
-
 [@dschaaff]: https://github.com/dschaaff
-
 [@dzinek]: https://github.com/dzinek
-
 [@eddmann]: https://github.com/eddmann
-
 [@erik-frontify]: https://github.com/erik-frontify
-
 [@evansj]: https://github.com/evansj
-
 [@ewansteele]: https://github.com/ewansteele
-
 [@ffleming]: https://github.com/ffleming
-
 [@ffrants]: https://github.com/ffrants
-
 [@florusboth]: https://github.com/florusboth
-
 [@flyinbutrs]: https://github.com/flyinbutrs
-
 [@flyinprogrammer]: https://github.com/flyinprogrammer
-
 [@fr3nd]: https://github.com/fr3nd
-
 [@fwelschen]: https://github.com/fwelschen
-
 [@fzwart]: https://github.com/fzwart
-
 [@generica]: https://github.com/generica
-
 [@gotyaio]: https://github.com/gotyaio
-
 [@grubernaut]: https://github.com/grubernaut
-
 [@jabbate19]: https://github.com/jabbate19
-
 [@jacobbednarz]: https://github.com/jacobbednarz
-
 [@jadams-av]: https://github.com/jadams-av
-
 [@jameynelson]: https://github.com/jameynelson
-
 [@jangie]: https://github.com/jangie
-
 [@jcarr-sailthru]: https://github.com/jcarr-sailthru
-
 [@jdavisp3]: https://github.com/jdavisp3
-
 [@jensendw]: https://github.com/jensendw
-
 [@jfrost]: https://github.com/jfrost
-
 [@jniesen]: https://github.com/jniesen
-
 [@jubagarie]: https://github.com/jubagarie
-
 [@jvanbrunschot]: https://github.com/jvanbrunschot
-
 [@kevin-bowers]: https://github.com/kevin-bowers
-
 [@kitchen]: https://github.com/kitchen
-
 [@lowkeyshift]: https://github.com/lowkeyshift
-
 [@mcasper]: https://github.com/mcasper
-
 [@milescrabill]: https://github.com/milescrabill
-
 [@mraylu]: https://github.com/mraylu
-
 [@mrunkel-ut]: https://github.com/mrunkel-ut
-
 [@mtougeron]: https://github.com/mtougeron
-
 [@murdok5]: https://github.com/murdok5
-
 [@npaufler]: https://github.com/npaufler
-
 [@o0oxid]: https://github.com/o0oxid
-
 [@obi11235]: https://github.com/obi11235
-
 [@obowersa]: https://github.com/obowersa
-
 [@oshmyrko]: https://github.com/oshmyrko
-
 [@pabrahamsson]: https://github.com/pabrahamsson
-
 [@paulhamby]: https://github.com/paulhamby
-
 [@pid1]: https://github.com/pid1
-
 [@pulkitsethi]: https://github.com/pulkitsethi
-
 [@rgergo]: https://github.com/rgergo
-
 [@rmrf-run]: https://github.com/rmrf-run
-
 [@rooprob]: https://github.com/rooprob
-
 [@rothgar]: https://github.com/rothgar
-
 [@rtyler]: https://github.com/rtyler
-
 [@rud]: https://github.com/rud
-
 [@ryan-dyer-sp]: https://github.com/ryan-dyer-sp
-
 [@sambanks]: https://github.com/sambanks
-
 [@samueljamesmarshall]: https://github.com/samueljamesmarshall
-
 [@scottgeary]: https://github.com/scottgeary
-
 [@sethcleveland]: https://github.com/sethcleveland
-
 [@siebrand]: https://github.com/siebrand
-
 [@skiedude]: https://github.com/skiedude
-
 [@spectralblu]: https://github.com/spectralblu
-
 [@stamak]: https://github.com/stamak
-
 [@stantona]: https://github.com/stantona
-
 [@swwolf]: https://github.com/swwolf
-
 [@szponek]: https://github.com/szponek
-
 [@tdm4]: https://github.com/tdm4
-
 [@teintuc]: https://github.com/teintuc
-
 [@tommoyangn]: https://github.com/tommoyangn
-
 [@turnopil]: https://github.com/turnopil
-
 [@tuxinaut]: https://github.com/tuxinaut
-
 [@vaisingh]: https://github.com/vaisingh
-
 [@yanjunding]: https://github.com/yanjunding
-
 [@yrcjaya]: https://github.com/yrcjaya
-
 [@zabacad]: https://github.com/zabacad
-
 [@zickzackv]: https://github.com/zickzackv
-
 [@zoom-kris-anderson]: https://github.com/zoom-kris-anderson

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This module installs the Datadog Agent and sends Puppet reports to Datadog.
 
 ### Requirements
 
-The Datadog Puppet module supports Linux and Windows and is compatible with Puppet >= 4.6.x or Puppet Enterprise version >= 2016.4. For detailed information on compatibility, check the [module page on Puppet Forge][1].
+The Datadog Puppet module supports Linux and Windows and is compatible with Puppet >= 7.34.x or Puppet Enterprise
+version >= 2021.7.x. For detailed information on compatibility, check the [module page on Puppet Forge][1].
 
 ### Installation
 
@@ -16,17 +17,25 @@ puppet module install datadog-datadog_agent
 
 #### Upgrading
 
-- By default Datadog Agent v7.x is installed. To use an earlier Agent version, change the setting `agent_major_version`.
-- `agent5_enable` is no longer used, as it has been replaced by `agent_major_version`.
-- `agent6_extra_options` has been renamed to `agent_extra_options` since it applies to both Agent v6 and v7.
-- `agent6_log_file` has been renamed to `agent_log_file` since it applies to both Agent v6 and v7.
-- `agent5_repo_uri` and `agent6_repo_uri` become `agent_repo_uri` for all Agent versions.
-- `conf_dir` and `conf6_dir` become `conf_dir` for all Agent versions.
-- The repository file created on Linux is named `datadog` for all Agent versions instead of `datadog5`/`datadog6`.
+> [!IMPORTANT]
+> The Datadog Puppet Module v4.x drops support for Puppet <= 6 and Datadog Agent v5. To upgrade or install the Datadog
+> Agent v5+ on Puppet <= 6, use module v3.x.
+
+- By default Datadog Agent v7.x is installed. To use Agent version 6, change the setting `agent_major_version`.
+- Agent v5-specific legacy options have been removed. Refer to the CHANGELOG.md for more details and the datadog_agent class comments for all available options.
+- Configuration options for the following integrations have been updated:
+  - ElasticSearch
+    - `ssl_verify` accepts only Boolean values
+    - `tls_verify`options have been added
+  - PostgreSQL
+    - `custom_metrics` option has been removed. Use `custom_queries` instead.
+  - TCP Check
+    -  `skip_event` option has been removed sinced Datadog Agent v6.4+
 
 ### Configuration
 
-Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaster` (or on a masterless host), follow these configuration steps:
+Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaster` (or on a masterless host), follow
+these configuration steps:
 
 1. Obtain your [Datadog API key][2].
 2. Add the Datadog class to your node manifests (eg: `/etc/puppetlabs/code/environments/production/manifests/site.pp`).
@@ -37,7 +46,7 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     }
     ```
 
-    If using a Datadog site other than the default 'datadoghq.com', set it here as well:
+   If using a Datadog site other than the default 'datadoghq.com', set it here as well:
 
     ```conf
     class { 'datadog_agent':
@@ -46,7 +55,7 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     }
     ```
 
-    For CentOS/RHEL versions <7.0 and for Ubuntu < 15.04, specify the service provider as `upstart`:
+   For CentOS/RHEL versions <7.0 and for Ubuntu < 15.04, specify the service provider as `upstart`:
 
     ```conf
     class { 'datadog_agent':
@@ -55,9 +64,10 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     }
     ```
 
-    See the [Configuration variables](#configuration-variables) section for list of arguments you can use here.
+   See the [Configuration variables](#configuration-variables) section for list of arguments you can use here.
 
-4. (Optional) Include any integrations you want to use with the Agent. The following example installs the mongo integration:
+4. (Optional) Include any integrations you want to use with the Agent. The following example installs the mongo
+   integration:
 
     ```conf
     class { 'datadog_agent::integrations::mongo':
@@ -65,9 +75,10 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
     }
     ```
 
-    See the [comments in code][6] for all arguments available for a given integration.
+   See the [comments in code][6] for all arguments available for a given integration.
 
-    If an integration does not have a [manifest with a dedicated class][7], you can still add a configuration for it. Below is an example for the `ntp` check:
+   If an integration does not have a [manifest with a dedicated class][7], you can still add a configuration for it.
+   Below is an example for the `ntp` check:
 
     ```conf
     class { 'datadog_agent':
@@ -87,7 +98,8 @@ Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaste
 
 ### Upgrading integrations
 
-To install and pin specific integration versions, use `datadog_agent::install_integration`. This calls the `datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
+To install and pin specific integration versions, use `datadog_agent::install_integration`. This calls the
+`datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
 
 ```conf
 datadog_agent::install_integration { "mongo-1.9":
@@ -109,7 +121,8 @@ Note it's not possible to downgrade an integration to a version older than the o
 
 ### Reporting
 
-To enable reporting of Puppet runs to your Datadog timeline, enable the report processor on your Puppet master and reporting for your clients. The clients send a run report after each check-in back to the master.
+To enable reporting of Puppet runs to your Datadog timeline, enable the report processor on your Puppet master and
+reporting for your clients. The clients send a run report after each check-in back to the master.
 
 1. Set the `puppet_run_reports` option to true in the node configuration manifest for your master:
 
@@ -121,7 +134,8 @@ To enable reporting of Puppet runs to your Datadog timeline, enable the report p
     }
     ```
 
-    The dogapi gem is automatically installed. Set `manage_dogapi_gem` to false if you want to customize the installation.
+   The dogapi gem is automatically installed. Set `manage_dogapi_gem` to false if you want to customize the
+   installation.
 
 2. Add these configuration options to the Puppet master config (eg: `/etc/puppetlabs/puppet/puppet.conf`):
 
@@ -183,14 +197,23 @@ With the [`ini_setting` module](https://forge.puppet.com/modules/puppetlabs/inif
 
 4. (Optional) Enable tagging of reports with facts:
 
-    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["certname","extensions.pp_role","hostname"]`.
+   You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the
+   given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to
+   ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to
+   the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the
+   parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example
+   `["certname","extensions.pp_role","hostname"]`.
 
-    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
+   NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report
+   processor. Ensure the changes are deployed prior to restarting the service(s).
 
-    Tips:
-    - Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not very useful)
-    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
-    - Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to the same tags from metrics
+   Tips:
+
+- Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not
+  very useful)
+- Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
+- Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to
+  the same tags from metrics
 
 5. Verify your Puppet data is in Datadog by searching for `sources:puppet` in the [Event Stream][5].
 
@@ -198,8 +221,10 @@ With the [`ini_setting` module](https://forge.puppet.com/modules/puppetlabs/inif
 
 To enable the Datadog Agent Network Performance Monitoring (NPM) features follow these steps:
 
-1. (Windows only) If the Agent is already installed, uninstall it by passing `win_ensure => absent` to the main class and removing other classes' definitions.
-2. (Windows only) Pass the `windows_npm_install` option with value `true` to the `datadog::datadog_agent` class. Remove `win_ensure` if added on previous step.
+1. (Windows only) If the Agent is already installed, uninstall it by passing `win_ensure => absent` to the main class
+   and removing other classes' definitions.
+2. (Windows only) Pass the `windows_npm_install` option with value `true` to the `datadog::datadog_agent` class. Remove
+   `win_ensure` if added on previous step.
 3. Use the `datadog_agent::system_probe` class to properly create the configuration file:
 
 ```conf
@@ -210,7 +235,8 @@ class { 'datadog_agent::system_probe':
 
 ### USM setup
 
-To enable the Datadog Agent Universal Service Monitoring (USM) use the `datadog_agent::system_probe` class to properly create the configuration file:
+To enable the Datadog Agent Universal Service Monitoring (USM) use the `datadog_agent::system_probe` class to properly
+create the configuration file:
 
 ```conf
 class { 'datadog_agent::system_probe':
@@ -264,14 +290,17 @@ If you don't see any reports coming in, check your Puppet server logs.
 
 ### Tagging client nodes
 
-The Datadog Agent configuration file is recreated from the template every Puppet run. If you need to tag your nodes, add an array entry in Hiera:
+The Datadog Agent configuration file is recreated from the template every Puppet run. If you need to tag your nodes, add
+an array entry in Hiera:
 
 ```conf
 datadog_agent::tags:
 - 'keyname:value'
 - 'anotherkey:%{factname}'
 ```
-To generate tags from custom facts classify your nodes with Puppet facts as an array to the ```facts_to_tags``` paramter either through the Puppet Enterprise console or Hiera. Here is an example:
+
+To generate tags from custom facts classify your nodes with Puppet facts as an array to the ```facts_to_tags``` paramter
+either through the Puppet Enterprise console or Hiera. Here is an example:
 
 ```conf
 class { "datadog_agent":
@@ -282,24 +311,27 @@ class { "datadog_agent":
 
 Tips:
 
-1. For structured facts index into the specific fact value otherwise the entire array comes over as a string and ultimately be difficult to use.
-2. Dynamic facts such as CPU usage, Uptime, and others that are expected to change each run are not ideal for tagging. Static facts that are expected to stay for the life of a node are best candidates for tagging.
+1. For structured facts index into the specific fact value otherwise the entire array comes over as a string and
+   ultimately be difficult to use.
+2. Dynamic facts such as CPU usage, Uptime, and others that are expected to change each run are not ideal for tagging.
+   Static facts that are expected to stay for the life of a node are best candidates for tagging.
 
 ### Configuration variables
 
-These variables can be set in the `datadog_agent` class to control settings in the Agent. See the [comments in code][8] for the full list of supported arguments.
+These variables can be set in the `datadog_agent` class to control settings in the Agent. See the [comments in code][8]
+for the full list of supported arguments.
 
 | variable name                           | description                                                                                                                                                                                      |
 |-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `agent_major_version`                   | The version of the Agent to install: either 5, 6 or 7 (default: 7).                                                                                                                              |
+| `agent_major_version`                   | The version of the Agent to install: either 6 or 7 (default: 7).                                                                                                                                 |
 | `agent_version`                         | Lets you pin a specific minor version of the Agent to install, for example: `1:7.16.0-1`. Leave empty to install the latest version.                                                             |
 | `collect_ec2_tags`                      | Collect an instance's custom EC2 tags as Agent tags by using `true`.                                                                                                                             |
 | `collect_instance_metadata`             | Collect an instance's EC2 metadata as Agent tags by using `true`.                                                                                                                                |
-| `datadog_site`                          | The Datadog site to report to (Agent v6 and v7 only). Defaults to `datadoghq.com`, eg: `datadoghq.eu` or `us3.datadoghq.com`.                                                          |
+| `datadog_site`                          | The Datadog site to report to. Defaults to `datadoghq.com`, eg: `datadoghq.eu` or `us3.datadoghq.com`.                                                                                           |
 | `dd_url`                                | The Datadog intake server URL. You are unlikely to need to change this. Overrides `datadog_site`                                                                                                 |
 | `host`                                  | Overrides the node's host name.                                                                                                                                                                  |
 | `local_tags`                            | An array of `<KEY:VALUE>` strings that are set as tags for the node.                                                                                                                             |
-| `non_local_traffic`                     | Allow other nodes to relay their traffic through this node.                                                                                                                                      |
+| `non_local_traffic`                     | Allow other nodes to relay their DogstatsD traffic through this node.                                                                                                                            |
 | `apm_enabled`                           | A boolean to enable the APM Agent (defaults to false).                                                                                                                                           |
 | `process_enabled`                       | A boolean to enable the process Agent (defaults to false).                                                                                                                                       |
 | `scrub_args`                            | A boolean to enable the process cmdline scrubbing (defaults to true).                                                                                                                            |
@@ -311,7 +343,8 @@ These variables can be set in the `datadog_agent` class to control settings in t
 | `agent_extra_options`<sup>1</sup>       | A hash to provide additional configuration options (Agent v6 and v7 only).                                                                                                                       |
 | `hostname_extraction_regex`<sup>2</sup> | A regex used to extract the hostname captured group to report the run in Datadog instead of reporting the Puppet nodename, for example:<br>`'^(?<hostname>.*\.datadoghq\.com)(\.i-\w{8}\..*)?$'` |
 
-(1) `agent_extra_options` is used to provide a fine grain control of additional Agent v6/v7 config options. A deep merge is performed that may override options provided in the `datadog_agent` class parameters. For example:
+(1) `agent_extra_options` is used to provide a fine grain control of additional Agent v6/v7 config options. A deep merge
+is performed that may override options provided in the `datadog_agent` class parameters. For example:
 
 ```
 class { "datadog_agent":
@@ -324,13 +357,21 @@ class { "datadog_agent":
 }
 ```
 
-(2) `hostname_extraction_regex` is useful when the Puppet module and the Datadog Agent are reporting different host names for the same host in the infrastructure list.
+(2) `hostname_extraction_regex` is useful when the Puppet module and the Datadog Agent are reporting different host
+names for the same host in the infrastructure list.
 
 [1]: https://forge.puppet.com/datadog/datadog_agent
+
 [2]: https://app.datadoghq.com/organization-settings/api-keys
+
 [3]: https://github.com/DataDog/dogapi-rb
+
 [4]: https://app.datadoghq.com/account/settings#integrations
+
 [5]: https://app.datadoghq.com/event/stream
+
 [6]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/integrations/mongo.pp
+
 [7]: https://github.com/DataDog/puppet-datadog-agent/tree/master/manifests/integrations
+
 [8]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/init.pp

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ puppet module install datadog-datadog_agent
 
 - By default Datadog Agent v7.x is installed. To use Agent version 6, change the setting `agent_major_version`.
 - Agent v5-specific legacy options have been removed. Refer to the CHANGELOG.md for more details and the datadog_agent class comments for all available options.
-- Configuration options for the following integrations have been updated:
+
+> [!IMPORTANT]
+> Updates and breaking changes have been made in the below agent integrations:
+
   - ElasticSearch **[BREAKING CHANGES]**
     - `ssl_verify` accepts only Boolean values
     - `tls_verify` options have been added
+  - Disk Check **[BREAKING CHANGES]**
+    - `use_mount`, `all_partitions`, and `tag_by_filesystem` accept only Boolean values
   - TCP Check
     -  `skip_event` option has been removed sinced Datadog Agent v6.4+
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ puppet module install datadog-datadog_agent
 
 ### Configuration
 
-Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaster` (or on a masterless host), follow
-these configuration steps:
+Once the `datadog_agent` module is installed on your `puppetserver`/`puppetmaster` (or on a masterless host), follow these configuration steps:
 
 1. Obtain your [Datadog API key][2].
 2. Add the Datadog class to your node manifests (eg: `/etc/puppetlabs/code/environments/production/manifests/site.pp`).
@@ -46,7 +45,7 @@ these configuration steps:
     }
     ```
 
-   If using a Datadog site other than the default 'datadoghq.com', set it here as well:
+    If using a Datadog site other than the default 'datadoghq.com', set it here as well:
 
     ```conf
     class { 'datadog_agent':
@@ -55,7 +54,7 @@ these configuration steps:
     }
     ```
 
-   For CentOS/RHEL versions <7.0 and for Ubuntu < 15.04, specify the service provider as `upstart`:
+    For CentOS/RHEL versions <7.0 and for Ubuntu < 15.04, specify the service provider as `upstart`:
 
     ```conf
     class { 'datadog_agent':
@@ -64,10 +63,9 @@ these configuration steps:
     }
     ```
 
-   See the [Configuration variables](#configuration-variables) section for list of arguments you can use here.
+    See the [Configuration variables](#configuration-variables) section for list of arguments you can use here.
 
-4. (Optional) Include any integrations you want to use with the Agent. The following example installs the mongo
-   integration:
+4. (Optional) Include any integrations you want to use with the Agent. The following example installs the mongo integration:
 
     ```conf
     class { 'datadog_agent::integrations::mongo':
@@ -75,10 +73,9 @@ these configuration steps:
     }
     ```
 
-   See the [comments in code][6] for all arguments available for a given integration.
+    See the [comments in code][6] for all arguments available for a given integration.
 
-   If an integration does not have a [manifest with a dedicated class][7], you can still add a configuration for it.
-   Below is an example for the `ntp` check:
+    If an integration does not have a [manifest with a dedicated class][7], you can still add a configuration for it. Below is an example for the `ntp` check:
 
     ```conf
     class { 'datadog_agent':
@@ -98,8 +95,7 @@ these configuration steps:
 
 ### Upgrading integrations
 
-To install and pin specific integration versions, use `datadog_agent::install_integration`. This calls the
-`datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
+To install and pin specific integration versions, use `datadog_agent::install_integration`. This calls the `datadog-agent integration` command to ensure a specific integration is installed or uninstalled, for example:
 
 ```conf
 datadog_agent::install_integration { "mongo-1.9":
@@ -121,8 +117,7 @@ Note it's not possible to downgrade an integration to a version older than the o
 
 ### Reporting
 
-To enable reporting of Puppet runs to your Datadog timeline, enable the report processor on your Puppet master and
-reporting for your clients. The clients send a run report after each check-in back to the master.
+To enable reporting of Puppet runs to your Datadog timeline, enable the report processor on your Puppet master and reporting for your clients. The clients send a run report after each check-in back to the master.
 
 1. Set the `puppet_run_reports` option to true in the node configuration manifest for your master:
 
@@ -134,8 +129,7 @@ reporting for your clients. The clients send a run report after each check-in ba
     }
     ```
 
-   The dogapi gem is automatically installed. Set `manage_dogapi_gem` to false if you want to customize the
-   installation.
+    The dogapi gem is automatically installed. Set `manage_dogapi_gem` to false if you want to customize the installation.
 
 2. Add these configuration options to the Puppet master config (eg: `/etc/puppetlabs/puppet/puppet.conf`):
 
@@ -197,23 +191,14 @@ With the [`ini_setting` module](https://forge.puppet.com/modules/puppetlabs/inif
 
 4. (Optional) Enable tagging of reports with facts:
 
-   You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the
-   given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to
-   ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to
-   the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the
-   parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example
-   `["certname","extensions.pp_role","hostname"]`.
+    You can add tags to reports that are sent to Datadog as events. These tags can be sourced from Puppet facts for the given node the report is regarding. These should be 1:1 and not involve structured facts (hashes, arrays, etc.) to ensure readability. To enable regular fact tagging, set the parameter `datadog_agent::reports::report_fact_tags` to the array value of facts—for example `["virtual","operatingsystem"]`. To enable trusted fact tagging, set the parameter `datadog_agent::reports::report_trusted_fact_tags` to the array value of facts—for example `["certname","extensions.pp_role","hostname"]`.
 
-   NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report
-   processor. Ensure the changes are deployed prior to restarting the service(s).
+    NOTE: Changing these settings requires a restart of pe-puppetserver (or puppetserver) to re-read the report processor. Ensure the changes are deployed prior to restarting the service(s).
 
-   Tips:
-
-- Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not
-  very useful)
-- Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
-- Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to
-  the same tags from metrics
+    Tips:
+    - Use dot index to specify a target fact; otherwise, the entire fact data set becomes the value as a string (not very useful)
+    - Do not duplicate common data from monitoring like hostname, uptime, memory, etc.
+    - Coordinate core facts like role, owner, template, datacenter, etc., that help you build meaningful correlations to the same tags from metrics
 
 5. Verify your Puppet data is in Datadog by searching for `sources:puppet` in the [Event Stream][5].
 
@@ -221,10 +206,8 @@ With the [`ini_setting` module](https://forge.puppet.com/modules/puppetlabs/inif
 
 To enable the Datadog Agent Network Performance Monitoring (NPM) features follow these steps:
 
-1. (Windows only) If the Agent is already installed, uninstall it by passing `win_ensure => absent` to the main class
-   and removing other classes' definitions.
-2. (Windows only) Pass the `windows_npm_install` option with value `true` to the `datadog::datadog_agent` class. Remove
-   `win_ensure` if added on previous step.
+1. (Windows only) If the Agent is already installed, uninstall it by passing `win_ensure => absent` to the main class and removing other classes' definitions.
+2. (Windows only) Pass the `windows_npm_install` option with value `true` to the `datadog::datadog_agent` class. Remove `win_ensure` if added on previous step.
 3. Use the `datadog_agent::system_probe` class to properly create the configuration file:
 
 ```conf
@@ -235,8 +218,7 @@ class { 'datadog_agent::system_probe':
 
 ### USM setup
 
-To enable the Datadog Agent Universal Service Monitoring (USM) use the `datadog_agent::system_probe` class to properly
-create the configuration file:
+To enable the Datadog Agent Universal Service Monitoring (USM) use the `datadog_agent::system_probe` class to properly create the configuration file:
 
 ```conf
 class { 'datadog_agent::system_probe':
@@ -290,17 +272,14 @@ If you don't see any reports coming in, check your Puppet server logs.
 
 ### Tagging client nodes
 
-The Datadog Agent configuration file is recreated from the template every Puppet run. If you need to tag your nodes, add
-an array entry in Hiera:
+The Datadog Agent configuration file is recreated from the template every Puppet run. If you need to tag your nodes, add an array entry in Hiera:
 
 ```conf
 datadog_agent::tags:
 - 'keyname:value'
 - 'anotherkey:%{factname}'
 ```
-
-To generate tags from custom facts classify your nodes with Puppet facts as an array to the ```facts_to_tags``` paramter
-either through the Puppet Enterprise console or Hiera. Here is an example:
+To generate tags from custom facts classify your nodes with Puppet facts as an array to the ```facts_to_tags``` paramter either through the Puppet Enterprise console or Hiera. Here is an example:
 
 ```conf
 class { "datadog_agent":
@@ -311,15 +290,12 @@ class { "datadog_agent":
 
 Tips:
 
-1. For structured facts index into the specific fact value otherwise the entire array comes over as a string and
-   ultimately be difficult to use.
-2. Dynamic facts such as CPU usage, Uptime, and others that are expected to change each run are not ideal for tagging.
-   Static facts that are expected to stay for the life of a node are best candidates for tagging.
+1. For structured facts index into the specific fact value otherwise the entire array comes over as a string and ultimately be difficult to use.
+2. Dynamic facts such as CPU usage, Uptime, and others that are expected to change each run are not ideal for tagging. Static facts that are expected to stay for the life of a node are best candidates for tagging.
 
 ### Configuration variables
 
-These variables can be set in the `datadog_agent` class to control settings in the Agent. See the [comments in code][8]
-for the full list of supported arguments.
+These variables can be set in the `datadog_agent` class to control settings in the Agent. See the [comments in code][8] for the full list of supported arguments.
 
 | variable name                           | description                                                                                                                                                                                      |
 |-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -343,8 +319,7 @@ for the full list of supported arguments.
 | `agent_extra_options`<sup>1</sup>       | A hash to provide additional configuration options (Agent v6 and v7 only).                                                                                                                       |
 | `hostname_extraction_regex`<sup>2</sup> | A regex used to extract the hostname captured group to report the run in Datadog instead of reporting the Puppet nodename, for example:<br>`'^(?<hostname>.*\.datadoghq\.com)(\.i-\w{8}\..*)?$'` |
 
-(1) `agent_extra_options` is used to provide a fine grain control of additional Agent v6/v7 config options. A deep merge
-is performed that may override options provided in the `datadog_agent` class parameters. For example:
+(1) `agent_extra_options` is used to provide a fine grain control of additional Agent v6/v7 config options. A deep merge is performed that may override options provided in the `datadog_agent` class parameters. For example:
 
 ```
 class { "datadog_agent":
@@ -357,21 +332,13 @@ class { "datadog_agent":
 }
 ```
 
-(2) `hostname_extraction_regex` is useful when the Puppet module and the Datadog Agent are reporting different host
-names for the same host in the infrastructure list.
+(2) `hostname_extraction_regex` is useful when the Puppet module and the Datadog Agent are reporting different host names for the same host in the infrastructure list.
 
 [1]: https://forge.puppet.com/datadog/datadog_agent
-
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-
 [3]: https://github.com/DataDog/dogapi-rb
-
 [4]: https://app.datadoghq.com/account/settings#integrations
-
 [5]: https://app.datadoghq.com/event/stream
-
 [6]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/integrations/mongo.pp
-
 [7]: https://github.com/DataDog/puppet-datadog-agent/tree/master/manifests/integrations
-
 [8]: https://github.com/DataDog/puppet-datadog-agent/blob/master/manifests/init.pp

--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ puppet module install datadog-datadog_agent
 - By default Datadog Agent v7.x is installed. To use Agent version 6, change the setting `agent_major_version`.
 - Agent v5-specific legacy options have been removed. Refer to the CHANGELOG.md for more details and the datadog_agent class comments for all available options.
 - Configuration options for the following integrations have been updated:
-  - ElasticSearch
+  - ElasticSearch **[BREAKING CHANGES]**
     - `ssl_verify` accepts only Boolean values
-    - `tls_verify`options have been added
-  - PostgreSQL
-    - `custom_metrics` option has been removed. Use `custom_queries` instead.
+    - `tls_verify` options have been added
   - TCP Check
     -  `skip_event` option has been removed sinced Datadog Agent v6.4+
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,9 +49,6 @@
 #   $non_local_traffic
 #       Enable you to use the agent as a proxy. Defaults to false.
 #       See https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration
-#   $dogstreams
-#       Optional array of logs to parse and custom parsers to use.
-#       See https://github.com/DataDog/dd-agent/blob/ed5e698/datadog.conf.example#L149-L178
 #   $log_level
 #       Set value of 'log_level' variable. Default is 'info' as in dd-agent.
 #       Valid values here are: critical, debug, error, fatal, info, warn and warning.
@@ -92,8 +89,6 @@
 #       separate way of adding keys.
 #   $skip_ssl_validation
 #       Skip SSL validation.
-#   $use_curl_http_client
-#       Uses the curl HTTP client for the forwarder
 #   $recent_point_threshold
 #       Sets the threshold for accepting points.
 #   String. Default: empty (30 second intervals)
@@ -146,12 +141,6 @@
 #       Default: empty
 #   $device_blacklist_re
 #       Specifies pattern for device blacklisting.
-#       String. Default: empty
-#   $dogstreams
-#       Specifies port for list of logstreams/modules to be used.
-#       String. Default: empty
-#   $custom_emitters
-#       Specifies a comma seperated list of non standard emitters to be used
 #       String. Default: empty
 #   $agent_log_file
 #       Specifies the log file location (Agent 6 and 7 only).
@@ -288,7 +277,6 @@ class datadog_agent (
   String $puppetmaster_user = $settings::user,
   String $puppet_gem_provider = $datadog_agent::params::gem_provider,
   Boolean $non_local_traffic = false,
-  Array $dogstreams = [],
   String $log_level = 'info',
   Boolean $log_to_syslog = true,
   String $service_ensure = 'running',
@@ -314,7 +302,6 @@ class datadog_agent (
   String $extra_template = '',
   Boolean $skip_ssl_validation = false,
   Boolean $skip_apt_key_trusting = false,
-  Boolean $use_curl_http_client = false,
   String $recent_point_threshold = '',
   Variant[Stdlib::Port, Pattern[/^\d*$/]] $listen_port = '',
   Optional[String] $additional_checksd = undef,
@@ -328,7 +315,6 @@ class datadog_agent (
   String $dogstatsd_interval = '',
   Boolean $dogstatsd_normalize = true,
   String $device_blacklist_re = '',
-  String $custom_emitters = '',
   String $agent_log_file = $datadog_agent::params::agent_log_file,
   String $collector_log_file = '',
   String $forwarder_log_file = '',

--- a/manifests/integrations/elasticsearch.pp
+++ b/manifests/integrations/elasticsearch.pp
@@ -34,8 +34,15 @@ class datadog_agent::integrations::elasticsearch (
   Boolean $pshard_stats      = false,
   Optional[String] $ssl_cert = undef,
   Optional[String] $ssl_key  = undef,
-  Boolean $ssl_verify        = true, #kept for backwards compatibility
+  Boolean $ssl_verify        = true, # kept for backwards compatibility
   Boolean $tls_verify        = $ssl_verify,
+  Boolean $tls_use_host_header = false,
+  Boolean $tls_ignore_warning  = false,
+  Optional[String] $tls_cert = undef,
+  Optional[String] $tls_private_key = undef,
+  Optional[String] $tls_ca_cert = undef,
+  Array $tls_protocols_allowed = [],
+  Array $tls_ciphers         = [],
   Array $tags                = [],
   String $url                = 'http://localhost:9200',
   Optional[String] $username = undef,
@@ -55,7 +62,14 @@ class datadog_agent::integrations::elasticsearch (
         'tls_verify'         => $tls_verify,
         'tags'               => $tags,
         'url'                => $url,
-        'username'           => $username
+        'username'           => $username,
+        'tls_use_host_header' => $tls_use_host_header,
+        'tls_ignore_warning'  => $tls_ignore_warning,
+        'tls_cert'            => $tls_cert,
+        'tls_private_key'     => $tls_private_key,
+        'tls_ca_cert'         => $tls_ca_cert,
+        'tls_protocols_allowed' => $tls_protocols_allowed,
+        'tls_ciphers'         => $tls_ciphers,
     }]
   } elsif !$instances {
     $_instances = []

--- a/manifests/integrations/postgres.pp
+++ b/manifests/integrations/postgres.pp
@@ -17,7 +17,19 @@
 #   $username
 #       The username for the datadog user
 #   $ssl
-#       Boolean to enable SSL
+#       This option determines whether or not and with what priority a secure SSL TCP/IP connection
+#         is negotiated with the server. There are six modes:
+#         - `disable`: Only tries a non-SSL connection.
+#         - `allow`: First tries a non-SSL connection; if if fails, tries an SSL connection.
+#         - `prefer`: First tries an SSL connection; if it fails, tries a non-SSL connection.
+#         - `require`: Only tries an SSL connection. If a root CA file is present, verifies the certificate in
+#                      the same way as if verify-ca was specified.
+#         - `verify-ca`: Only tries an SSL connection, and verifies that the server certificate is issued by a
+#                        trusted certificate authority (CA).
+#         - `verify-full`: Only tries an SSL connection and verifies that the server certificate is issued by a
+#                          trusted CA and that the requested server host name matches the one in the certificate.
+#
+#         For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
 #   $use_psycopg2
 #       Boolean to flag connecting to postgres with psycopg2 instead of pg8000.
 #       Warning, psycopg2 doesn't support ssl mode.
@@ -41,6 +53,10 @@
 #       (10 + 10 per index)
 #   $tags
 #       Optional array of tags
+#   $custom_metrics
+#       A hash of custom metrics with the following keys - query, metrics,
+#       relation, descriptors. Refer to this guide for details on those fields:
+#       https://help.datadoghq.com/hc/en-us/articles/208385813-Postgres-custom-metric-collection-explained
 #
 # Sample Usage:
 #
@@ -50,6 +66,18 @@
 #    username => 'datadog',
 #    password => 'some_pass',
 #    ssl      => false,
+#    custom_metrics => {
+#      a_custom_query => {
+#        query => "select tag_column, %s from table",
+#        relation => false,
+#        metrics => {
+#          value_column => ["value_column.datadog.tag", "GAUGE"]
+#        },
+#        descriptors => [
+#          ["tag_column", "tag_column.datadog.tag"]
+#        ]
+#      }
+#    }
 #  }
 #
 # Hiera Usage:
@@ -59,7 +87,15 @@
 #       dbname: 'postgres'
 #       username: 'datadog'
 #       password: 'some_pass'
-#       ssl: false
+#       ssl: 'allow'
+#       custom_metrics:
+#         a_custom_query:
+#           query: 'select tag_column, %s from table'
+#           relation: false
+#           metrics:
+#             value_column: ["value_column.datadog.tag", "GAUGE"]
+#           descriptors:
+#           - ["tag_column", "tag_column.datadog.tag"]
 #
 class datadog_agent::integrations::postgres (
   Optional[String] $password             = undef,
@@ -67,7 +103,7 @@ class datadog_agent::integrations::postgres (
   String $dbname                         = 'postgres',
   Variant[String, Integer] $port         = '5432',
   String $username                       = 'datadog',
-  Boolean $ssl                           = false,
+  String $ssl                            = 'allow',
   Boolean $use_psycopg2                  = false,
   Boolean $collect_function_metrics      = false,
   Boolean $collect_count_metrics         = false,
@@ -76,6 +112,7 @@ class datadog_agent::integrations::postgres (
   Boolean $collect_default_database      = false,
   Array[String] $tags                    = [],
   Array[String] $tables                  = [],
+  Hash $custom_metrics                   = {},
   Optional[Array] $instances             = undef,
 ) inherits datadog_agent::params {
   require datadog_agent
@@ -103,6 +140,7 @@ class datadog_agent::integrations::postgres (
         'use_psycopg2'                  => $use_psycopg2,
         'tags'                          => $tags,
         'tables'                        => $tables,
+        'custom_metrics'                => $custom_metrics,
         'collect_function_metrics'      => $collect_function_metrics,
         'collect_count_metrics'         => $collect_count_metrics,
         'collect_activity_metrics'      => $collect_activity_metrics,
@@ -124,4 +162,6 @@ class datadog_agent::integrations::postgres (
     require => Package[$datadog_agent::params::package_name],
     notify  => Service[$datadog_agent::params::service_name],
   }
+
+  create_resources('datadog_agent::integrations::postgres_custom_metric', $custom_metrics)
 }

--- a/manifests/integrations/postgres_custom_metric.pp
+++ b/manifests/integrations/postgres_custom_metric.pp
@@ -1,0 +1,27 @@
+##
+# The postgres_custom_metric defines a custom sql metric.
+# https://help.datadoghq.com/hc/en-us/articles/208385813-Postgres-custom-metric-collection-explained
+#
+# $query:
+#   The custom metric SQL query. It must contain a '%s' for defining the metrics.
+#
+# $metrics:
+#   a hash of column name to metric definition. a metric definition is an array
+#   consisting of two columns -- the datadog metric name and the metric type.
+#
+# $relation:
+#   ?
+#
+# $descriptor:
+#   an array that maps an sql column's to a tag. Each descriptor consists of two
+#   fields -- column name, and datadog tag.
+define datadog_agent::integrations::postgres_custom_metric (
+  String $query,
+  Hash $metrics,
+  Boolean $relation = false,
+  Array $descriptors = [],
+) {
+  if $query !~ '^.*%s.*$' {
+    fail('custom_metrics require %s for metric substitution')
+  }
+}

--- a/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
+++ b/spec/classes/datadog_agent_integrations_elasticsearch_spec.rb
@@ -28,8 +28,11 @@ describe 'datadog_agent::integrations::elasticsearch' do
         it { is_expected.not_to contain_file(conf_file).with_content(%r{      username}) }
         it { is_expected.not_to contain_file(conf_file).with_content(%r{      password}) }
         it { is_expected.not_to contain_file(conf_file).with_content(%r{      tls_verify}) }
-        it { is_expected.not_to contain_file(conf_file).with_content(%r{      ssl_cert}) }
-        it { is_expected.not_to contain_file(conf_file).with_content(%r{      ssl_key}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      tls_cert}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      tls_ca_cert}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      tls_private_key}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      tls_use_host_header}) }
+        it { is_expected.not_to contain_file(conf_file).with_content(%r{      tls_ignore_warning}) }
         it { is_expected.not_to contain_file(conf_file).with_content(%r{      tags:}) }
       end
 
@@ -40,9 +43,14 @@ describe 'datadog_agent::integrations::elasticsearch' do
             pending_task_stats: false,
             url:                'https://foo:4242',
             username:           'username',
-            ssl_cert:           '/etc/ssl/certs/client.pem',
-            ssl_key:            '/etc/ssl/private/client.key',
-            tags:               ['tag1:key1'],
+            tls_cert:           '/etc/ssl/certs/client.pem',
+            tls_ca_cert:        '/etc/ssl/certs/ca.pem',
+            tls_private_key:    '/etc/ssl/private/client.key',
+            tls_use_host_header: true,
+            tls_ignore_warning:  true,
+            tls_protocols_allowed: ['TLSv1.2', 'TLSv1.3'],
+            tls_ciphers:           ['TLS_AES_256_GCM_SHA384', 'TLS_CHACHA20_POLY1305_SHA256'],
+            tags:                  ['tag1:key1'],
           }
         end
 
@@ -50,11 +58,20 @@ describe 'datadog_agent::integrations::elasticsearch' do
         it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: false}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      username: username}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      password: password}) }
-        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_verify: true}) }
-        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
-        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      tags:}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{        - tag1:key1}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_verify: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_cert: /etc/ssl/certs/client.pem}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_ca_cert: /etc/ssl/certs/ca.pem}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_private_key: /etc/ssl/private/client.key}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_use_host_header: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_ignore_warning: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_protocols_allowed:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLSv1.2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLSv1.3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_ciphers:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLS_AES_256_GCM_SHA384}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLS_CHACHA20_POLY1305_SHA256}) }
       end
 
       context 'with multiple instances set' do
@@ -70,8 +87,8 @@ describe 'datadog_agent::integrations::elasticsearch' do
                 'url'                => 'https://foo:4242',
                 'username'           => 'username',
                 'tls_verify'         => true,
-                'ssl_cert'           => '/etc/ssl/certs/client.pem',
-                'ssl_key'            => '/etc/ssl/private/client.key',
+                'tls_cert'           => '/etc/ssl/certs/client.pem',
+                'tls_private_key'    => '/etc/ssl/private/client.key',
                 'tags'               => ['tag1:key1'],
               },
               {
@@ -84,6 +101,10 @@ describe 'datadog_agent::integrations::elasticsearch' do
                 'username'           => 'username_2',
                 'tls_verify'         => false,
                 'tags'               => ['tag2:key2'],
+                'tls_use_host_header' => true,
+                'tls_ignore_warning'  => true,
+                'tls_protocols_allowed' => ['TLSv1.2', 'TLSv1.3'],
+                'tls_ciphers'           => ['TLS_AES_256_GCM_SHA384', 'TLS_CHACHA20_POLY1305_SHA256'],
               },
             ],
           }
@@ -98,8 +119,8 @@ describe 'datadog_agent::integrations::elasticsearch' do
         it { is_expected.to contain_file(conf_file).with_content(%r{      password: password}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: true}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      tls_verify: true}) }
-        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_cert: /etc/ssl/certs/client.pem}) }
-        it { is_expected.to contain_file(conf_file).with_content(%r{      ssl_key: /etc/ssl/private/client.key}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_cert: /etc/ssl/certs/client.pem}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_private_key: /etc/ssl/private/client.key}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      tags:\n        - tag1:key1}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://bar:2424}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
@@ -110,6 +131,38 @@ describe 'datadog_agent::integrations::elasticsearch' do
         it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      tls_verify: false}) }
         it { is_expected.to contain_file(conf_file).with_content(%r{      tags:\n        - tag2:key2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_use_host_header: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_ignore_warning: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_protocols_allowed:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLSv1.2}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLSv1.3}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_ciphers:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLS_AES_256_GCM_SHA384}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{        - TLS_CHACHA20_POLY1305_SHA256}) }
+      end
+
+      context 'with legacy ssl_verify parameter set' do
+        let(:params) do
+          {
+            password:    'password',
+            url:         'https://foo:4242',
+            username:    'username',
+            ssl_verify:  true,
+            tls_cert:    '/etc/ssl/certs/client.pem',
+            tls_ca_cert: '/etc/ssl/certs/ca.pem',
+            tls_private_key: '/etc/ssl/private/client.key',
+          }
+        end
+
+        it { is_expected.to contain_file(conf_file).with_content(%r{instances:}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{    - url: https://foo:4242}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      cluster_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      index_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pending_task_stats: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      pshard_stats: false}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_verify: true}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_cert: /etc/ssl/certs/client.pem}) }
+        it { is_expected.to contain_file(conf_file).with_content(%r{      tls_private_key: /etc/ssl/private/client.key}) }
       end
     end
   end

--- a/spec/classes/datadog_agent_integrations_postgres_spec.rb
+++ b/spec/classes/datadog_agent_integrations_postgres_spec.rb
@@ -97,6 +97,59 @@ describe 'datadog_agent::integrations::postgres' do
           it { is_expected.to contain_file(conf_file).with_content(%r{username: monitoring}) }
           it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*tags:\s+- foo\s+- bar\s+- baz}) }
           it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*relations:\s+- furry\s+- fuzzy\s+- funky}) }
+
+          context 'with custom metric query missing %s' do
+            let(:params) do
+              {
+                host: 'postgres1',
+                dbname: 'cats',
+                port: 4142,
+                username: 'monitoring',
+                password: 'abc123',
+                custom_metrics: {
+                  'query_is_missing_%s' => {
+                    'query' => 'select * from fuzz',
+                    'metrics' => {},
+                  },
+                },
+              }
+            end
+
+            it do
+              expect {
+                is_expected.to compile
+              }.to raise_error(%r{custom_metrics require %s for metric substitution})
+            end
+          end
+
+          context 'with custom metric query' do
+            let(:params) do
+              {
+                host: 'postgres1',
+                dbname: 'cats',
+                port: 4142,
+                username: 'monitoring',
+                password: 'abc123',
+                custom_metrics: {
+                  'foo_gooo_bar_query' => {
+                    'query' => 'select foo, %s from bar',
+                    'metrics' => {
+                      'gooo' => ['custom_metric.tag.gooo', 'GAUGE'],
+                    },
+                    'descriptors' => [['foo', 'custom_metric.tag.foo']],
+                  },
+                },
+              }
+            end
+
+            it { is_expected.to compile }
+            it { is_expected.to contain_file(conf_file).with_content(%r{^[^#]*custom_metrics:}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+query:\s*['"]?select foo, %s from bar['"]?}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+metrics:}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+"gooo":\s+\[custom_metric.tag.gooo, GAUGE\]}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+query.*[\r\n]+\s+relation:\s*false}) }
+            it { is_expected.to contain_file(conf_file).with_content(%r{\s+descriptors.*[\r\n]+\s+-\s+\[foo, custom_metric.tag.foo\]}) }
+          end
         end
       end
     end

--- a/templates/agent-conf.d/elastic.yaml.erb
+++ b/templates/agent-conf.d/elastic.yaml.erb
@@ -18,16 +18,37 @@ instances:
 <%- if instance['url'].match(/^https/) -%>
       tls_verify: <%= instance['tls_verify'] %>
 <%- end -%>
-<%- if instance['ssl_cert'] && instance['ssl_cert'] != :undef -%>
-      ssl_cert: <%= instance['ssl_cert'] %>
+<%- if instance['tls_cert'] && instance['tls_cert'] != :undef -%>
+      tls_cert: <%= instance['tls_cert'] %>
 <%- end -%>
-<%- if instance['ssl_key'] && instance['ssl_key'] != :undef -%>
-      ssl_key: <%= instance['ssl_key'] %>
+<%- if instance['tls_ca_cert'] && instance['tls_ca_cert'] != :undef -%>
+      tls_ca_cert: <%= instance['tls_ca_cert'] %>
+<%- end -%>
+<%- if instance['tls_private_key'] && instance['tls_private_key'] != :undef -%>
+      tls_private_key: <%= instance['tls_private_key'] %>
+<%- end -%>
+<%- if instance['tls_use_host_header'] && instance['tls_use_host_header'] != :undef -%>
+      tls_use_host_header: <%= instance['tls_use_host_header'] %>
+<%- end -%>
+<%- if instance['tls_ignore_warning'] && instance['tls_ignore_warning'] != :undef -%>
+      tls_ignore_warning: <%= instance['tls_ignore_warning'] %>
 <%- end -%>
 <%- unless instance['tags'].empty? -%>
       tags:
   <%- instance['tags'].each do |tag| -%>
         - <%= tag %>
+  <%- end -%>
+<%- end -%>
+<%- unless instance['tls_protocols_allowed'].nil? -%>
+      tls_protocols_allowed:
+  <%- instance['tls_protocols_allowed'].each do |protocol| -%>
+        - <%= protocol %>
+  <%- end -%>
+<%- end -%>
+<%- unless instance['tls_ciphers'].nil? -%>
+      tls_ciphers:
+  <%- instance['tls_ciphers'].each do |cipher| -%>
+        - <%= cipher %>
   <%- end -%>
 <%- end -%>
 <%- end -%>

--- a/templates/datadog_footer.conf.erb
+++ b/templates/datadog_footer.conf.erb
@@ -27,13 +27,6 @@ recent_point_threshold: <%= @recent_point_threshold %>
 listen_port: <%= @listen_port %>
 <% end -%>
 
-# Start a graphite listener on this port
-<% if @graphite_listen_port.to_s.empty? -%>
-# graphite_listen_port: 17124
-<% else -%>
-graphite_listen_port: <%= @graphite_listen_port %>
-<% end -%>
-
 # Additional directory to look for Datadog checks
 <% if @additional_checksd.nil? -%>
 # additional_checksd: /etc/dd-agent/checks.d/
@@ -47,10 +40,6 @@ additional_checksd: <%= @additional_checksd %>
 # For more information, please see
 # https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
 non_local_traffic: <%= @non_local_traffic %>
-
-# Select the Tornado HTTP Client in the forwarder
-# Default to the simple http client
-use_curl_http_client: <%= @use_curl_http_client %>
 
 # The loopback address the Forwarder and Dogstatsd will bind.
 # Optional, it is mainly used when running the agent on Openshift
@@ -161,61 +150,6 @@ statsd_forward_port: <%= @statsd_forward_port %>
 <% else -%>
 device_blacklist_re: <%= @device_blacklist_re %>
 <% end -%>
-
-# -------------------------------------------------------------------------- #
-#  Dogstream (log file parser)
-# -------------------------------------------------------------------------- #
-
-# Comma-separated list of logs to parse and optionally custom parsers to use.
-# The form should look like this:
-#
-#   dogstreams: /path/to/log1:parsers_module:custom_parser, /path/to/log2, /path/to/log3, ...
-#
-# Or this:
-#
-#   dogstreams: /path/to/log1:/path/to/my/parsers_module.py:custom_parser, /path/to/log2, /path/to/log3, ...
-#
-# Each entry is a path to a log file and optionally a Python module/function pair
-# separated by colons.
-#
-# Custom parsers should take a 2 parameters, a logger object and
-# a string parameter of the current line to parse. It should return a tuple of
-# the form:
-#   (metric (str), timestamp (unix timestamp), value (float), attributes (dict))
-# where attributes should at least contain the key 'metric_type', specifying
-# whether the given metric is a 'counter' or 'gauge'.
-#
-# Unless parsers are specified with an absolute path, the modules must exist in
-# the Agent's PYTHONPATH. You can set this as an environment variable when
-# starting the Agent. If the name of the custom parser function is not passed,
-# 'parser' is assumed.
-#
-# If this value isn't specified, the default parser assumes this log format:
-#     metric timestamp value key0=val0 key1=val1 ...
-#
-<%
-if not @dogstreams.empty?
--%>
-dogstreams: <%= @dogstreams.join(', ') %>
-<% end -%>
-
-# ========================================================================== #
-# Custom Emitters                                                            #
-# ========================================================================== #
-
-# Comma-separated list of emitters to be used in addition to the standard one
-#
-# Expected to be passed as a comma-separated list of colon-delimited
-# name/object pairs.
-#
-<% if @custom_emitters.empty? -%>
-# custom_emitters: /usr/local/my-code/emitters/rabbitmq.py:RabbitMQEmitter
-<% else -%>
-custom_emitters: <%= @custom_emitters %>
-<% end -%>
-#
-# If the name of the emitter function is not specified, 'emitter' is assumed.
-
 
 # ========================================================================== #
 # Logging


### PR DESCRIPTION
### What does this PR do?

* Add back reverted postgres ssl changes, add back removed `custom_metrics` option (will add the new `custom_queries` option after v4 is released)
* Add updated tls options to elastic check
* Update changelog and readme
* A few more Agent 5 cleanups

CI: https://app.circleci.com/pipelines/github/DataDog/puppet-datadog-agent/1160/workflows/56cd05eb-65e0-410d-9a96-1b1fca6fb3c0

### Motivation

<!--What inspired you to submit this pull request?-->

### Additional Notes

<!--Anything else we should know when reviewing?-->

### Describe your test plan

<!--Write there any instructions and details you may have to test your PR.-->
